### PR TITLE
Add options to control SRT TSBPD mode and too-late packet drop mode

### DIFF
--- a/srt/src/sys.rs
+++ b/srt/src/sys.rs
@@ -5,7 +5,9 @@ pub type SRTSOCKET = int;
 #[repr(C)]
 #[allow(non_camel_case_types)]
 pub enum SRT_SOCKOPT {
+    TSBPDMODE = 22,
     PASSPHRASE = 26,
+    TLPKTDROP = 31,
     STREAMID = 46,
 }
 


### PR DESCRIPTION
See: https://github.com/Haivision/srt/blob/master/docs/API.md

These modes aren't desirable for server applications where we want to minimize latency and maximize robustness.