### PR TITLE
segmenting fix for mpeg-ts streams without RAIs

### DIFF
--- a/h264/src/nal_unit.rs
+++ b/h264/src/nal_unit.rs
@@ -6,6 +6,7 @@ use std::io;
 /// NALU, mask the first byte with this.
 pub const NAL_UNIT_TYPE_MASK: u8 = 0x1f;
 
+pub const NAL_UNIT_TYPE_CODED_SLICE_OF_IDR_PICTURE: u8 = 5;
 pub const NAL_UNIT_TYPE_SEQUENCE_PARAMETER_SET: u8 = 7;
 pub const NAL_UNIT_TYPE_PICTURE_PARAMETER_SET: u8 = 8;
 

--- a/mpegts-segmenter/src/analyzer.rs
+++ b/mpegts-segmenter/src/analyzer.rs
@@ -354,6 +354,13 @@ impl Analyzer {
         }
     }
 
+    pub fn stream(&self, pid: u16) -> Option<&Stream> {
+        match &self.pids[pid as usize] {
+            PIDState::PES { stream } => Some(stream),
+            _ => None,
+        }
+    }
+
     pub fn is_video(&self, pid: u16) -> bool {
         match &self.pids[pid as usize] {
             PIDState::PES { stream } => stream.is_video(),

--- a/srt/src/lib.rs
+++ b/srt/src/lib.rs
@@ -120,6 +120,12 @@ impl ToOption for bool {
     }
 }
 
+impl ToOption for i32 {
+    fn set(&self, sock: sys::SRTSOCKET, opt: sys::SRT_SOCKOPT) -> Result<()> {
+        check_code(unsafe { sys::srt_setsockopt(sock, 0, opt, self as *const i32 as *const _, std::mem::size_of::<i32>() as _) })
+    }
+}
+
 trait FromOption: Sized {
     fn get(sock: sys::SRTSOCKET, opt: sys::SRT_SOCKOPT) -> Result<Self>;
 }
@@ -254,6 +260,7 @@ extern "C" fn listener_callback(
 pub enum ListenerOption {
     TimestampBasedPacketDeliveryMode(bool),
     TooLatePacketDrop(bool),
+    ReceiveBufferSize(i32),
 }
 
 impl ListenerOption {
@@ -261,6 +268,7 @@ impl ListenerOption {
         match self {
             ListenerOption::TimestampBasedPacketDeliveryMode(v) => sock.set(sys::SRT_SOCKOPT::TSBPDMODE, *v),
             ListenerOption::TooLatePacketDrop(v) => sock.set(sys::SRT_SOCKOPT::TLPKTDROP, *v),
+            ListenerOption::ReceiveBufferSize(v) => sock.set(sys::SRT_SOCKOPT::RCVBUF, *v),
         }
     }
 }

--- a/srt/src/sys.rs
+++ b/srt/src/sys.rs
@@ -5,6 +5,7 @@ pub type SRTSOCKET = int;
 #[repr(C)]
 #[allow(non_camel_case_types)]
 pub enum SRT_SOCKOPT {
+    RCVBUF = 6,
     TSBPDMODE = 22,
     PASSPHRASE = 26,
     TLPKTDROP = 31,


### PR DESCRIPTION
* Fixes segmenting for streams without RAIs and adds a unit test.
* Adds recv buffer size option for SRT.