### PR TITLE
improve h265 frame counting

### DIFF
--- a/h265/src/nal_unit.rs
+++ b/h265/src/nal_unit.rs
@@ -41,7 +41,7 @@ impl Decode for NALUnitHeader {
             &mut ret.nuh_temporal_id_plus1
         )?;
 
-        if ret.forbidden_zero_bit.0 != 0 {
+        if ret.nal_unit_type.0 < 48 && ret.forbidden_zero_bit.0 != 0 {
             return Err(io::Error::new(io::ErrorKind::Other, "non-zero forbidden_zero_bit"));
         }
 

--- a/h265/src/slice_segment_header.rs
+++ b/h265/src/slice_segment_header.rs
@@ -1,0 +1,17 @@
+use super::{decode, syntax_elements::*, Bitstream, Decode};
+use std::io;
+
+#[derive(Debug, Default)]
+pub struct SliceSegmentHeader {
+    pub first_slice_segment_in_pic_flag: U1,
+}
+
+impl Decode for SliceSegmentHeader {
+    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+        let mut ret = Self::default();
+
+        decode!(bs, &mut ret.first_slice_segment_in_pic_flag)?;
+
+        Ok(ret)
+    }
+}

--- a/mpegts-segmenter/src/analyzer.rs
+++ b/mpegts-segmenter/src/analyzer.rs
@@ -557,4 +557,37 @@ mod test {
             ]
         );
     }
+
+    #[tokio::test]
+    async fn test_analyzer_h265_8k() {
+        let mut analyzer = Analyzer::new();
+
+        {
+            let mut f = File::open("src/testdata/h265-8k.ts").unwrap();
+            let mut buf = Vec::new();
+            f.read_to_end(&mut buf).unwrap();
+            let packets = ts::decode_packets(&buf).unwrap();
+            analyzer.handle_packets(&packets).unwrap();
+            analyzer.flush().unwrap();
+        }
+
+        assert_eq!(
+            analyzer.streams(),
+            vec![
+                StreamInfo::Video {
+                    width: 7680,
+                    height: 4320,
+                    frame_rate: 59.94,
+                    frame_count: 24,
+                    rfc6381_codec: Some("hvc1.2.6.L180.B0".to_string()),
+                },
+                StreamInfo::Audio {
+                    channel_count: 2,
+                    sample_rate: 48000,
+                    sample_count: 37888,
+                    rfc6381_codec: Some("mp4a.40.2".to_string()),
+                }
+            ]
+        );
+    }
 }

--- a/mpegts-segmenter/src/analyzer.rs
+++ b/mpegts-segmenter/src/analyzer.rs
@@ -578,13 +578,13 @@ mod test {
                     width: 7680,
                     height: 4320,
                     frame_rate: 59.94,
-                    frame_count: 24,
+                    frame_count: 31,
                     rfc6381_codec: Some("hvc1.2.6.L180.B0".to_string()),
                 },
                 StreamInfo::Audio {
                     channel_count: 2,
                     sample_rate: 48000,
-                    sample_count: 37888,
+                    sample_count: 49152,
                     rfc6381_codec: Some("mp4a.40.2".to_string()),
                 }
             ]


### PR DESCRIPTION
Basically the same thing as https://github.com/sportsball-ai/av-rs/pull/11 but for H265. Fortunately this is actually much easier for H265 than for H264.