### PR TITLE
add encoding support for h264 / h265

### DIFF
--- a/h264/Cargo.toml
+++ b/h264/Cargo.toml
@@ -2,3 +2,6 @@
 name = "h264"
 version = "0.1.0"
 edition = "2018"
+
+[dependencies]
+bytes = "0.5.6"

--- a/h264/src/bitstream.rs
+++ b/h264/src/bitstream.rs
@@ -38,6 +38,10 @@ impl<'a, T: Iterator<Item = &'a u8>> Bitstream<T> {
         true
     }
 
+    pub fn bits(&mut self) -> BitstreamBits<T> {
+        BitstreamBits { bs: self }
+    }
+
     pub fn next_bits(&mut self, n: usize) -> Option<u64> {
         while self.next_bits_length < n {
             let b = *self.inner.next()? as u128;
@@ -67,8 +71,88 @@ impl<'a, T: Iterator<Item = &'a u8>> Bitstream<T> {
     }
 }
 
+pub struct BitstreamBits<'a, T> {
+    bs: &'a mut Bitstream<T>,
+}
+
+impl<'a, 'b: 'a, T: Iterator<Item = &'b u8>> Iterator for BitstreamBits<'a, T> {
+    type Item = bool;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.bs.read_bits(1).ok().map(|n| n == 1)
+    }
+}
+
 pub trait Decode: Sized {
     fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self>;
+}
+
+pub struct BitstreamWriter<T: io::Write> {
+    inner: T,
+    next_bits: u128,
+    next_bits_length: usize,
+}
+
+impl<T: io::Write> BitstreamWriter<T> {
+    pub fn new(inner: T) -> Self {
+        Self {
+            inner,
+            next_bits: 0,
+            next_bits_length: 0,
+        }
+    }
+
+    pub fn byte_aligned(&self) -> bool {
+        self.next_bits_length % 8 == 0
+    }
+
+    // Writes the given bits to the bitstream. If an error occurs, it is undefined how many bits
+    // were actually written to the underlying bitstream.
+    pub fn write_bits(&mut self, bits: u64, len: usize) -> io::Result<()> {
+        self.next_bits = (self.next_bits << len) | bits as u128;
+        self.next_bits_length += len;
+        while self.next_bits_length >= 8 {
+            let next_byte = (self.next_bits >> (self.next_bits_length - 8)) as u8;
+            self.inner.write(&[next_byte])?;
+            self.next_bits_length -= 8;
+        }
+        Ok(())
+    }
+
+    // Writes the remaining bits to the underlying writer if there are any, and flushes it. If the
+    // bitstream is not byte-aligned, zero-bits will be appended until it is.
+    pub fn flush(&mut self) -> io::Result<()> {
+        if self.next_bits_length > 0 {
+            let next_byte = (self.next_bits << (8 - self.next_bits_length)) as u8;
+            self.inner.write(&[next_byte])?;
+            self.next_bits_length = 0;
+        }
+        self.inner.flush()
+    }
+
+    pub fn encode<V: Encode>(&mut self, v: &V) -> io::Result<()> {
+        v.encode(self)
+    }
+}
+
+impl<T: io::Write> Drop for BitstreamWriter<T> {
+    fn drop(&mut self) {
+        // if users need the error, they should explicitly invoke flush before dropping
+        let _ = self.flush();
+    }
+}
+
+pub trait Encode: Sized {
+    fn encode<'a, T: io::Write>(&self, bs: &mut BitstreamWriter<T>) -> io::Result<()>;
+}
+
+impl<T: Encode> Encode for Vec<T> {
+    fn encode<'a, U: io::Write>(&self, bs: &mut BitstreamWriter<U>) -> io::Result<()> {
+        for v in self {
+            v.encode(bs)?;
+        }
+        Ok(())
+    }
 }
 
 #[macro_export]
@@ -78,6 +162,16 @@ macro_rules! decode {
     }};
     ($b:expr, $e:expr, $($r:expr),+) => {
         decode!($b, $e).and(decode!($b, $($r),+))
+    };
+}
+
+#[macro_export]
+macro_rules! encode {
+    ($b:expr, $e:expr) => {{
+        $b.encode($e)
+    }};
+    ($b:expr, $e:expr, $($r:expr),+) => {
+        encode!($b, $e).and(encode!($b, $($r),+))
     };
 }
 
@@ -93,5 +187,12 @@ mod test {
         decode!(bs, &mut a, &mut b).unwrap();
         assert_eq!(a.0, 2);
         assert_eq!(b.0, 1);
+    }
+
+    #[test]
+    fn test_encode() {
+        let mut b = Vec::new();
+        BitstreamWriter::new(&mut b).write_bits(0x0102, 18).unwrap();
+        assert_eq!(b, &[0x00, 0x40, 0x80]);
     }
 }

--- a/h265/src/lib.rs
+++ b/h265/src/lib.rs
@@ -3,10 +3,13 @@ use std::io;
 pub mod nal_unit;
 pub use nal_unit::*;
 
-pub use h264::decode;
+pub use h264::{decode, encode};
 
 pub use h264::bitstream;
 pub use h264::bitstream::*;
+
+pub mod picture_parameter_set;
+pub use picture_parameter_set::*;
 
 pub mod profile_tier_level;
 pub use profile_tier_level::*;
@@ -23,7 +26,7 @@ pub use video_parameter_set::*;
 pub mod syntax_elements;
 pub use syntax_elements::*;
 
-pub use h264::{iterate_annex_b, iterate_avcc};
+pub use h264::{iterate_annex_b, iterate_avcc, read_annex_b};
 
 #[derive(Clone)]
 pub struct AccessUnitCounter {

--- a/h265/src/nal_unit.rs
+++ b/h265/src/nal_unit.rs
@@ -4,6 +4,7 @@ use std::io;
 
 pub const NAL_UNIT_TYPE_VIDEO_PARAMETER_SET: u8 = 32;
 pub const NAL_UNIT_TYPE_SEQUENCE_PARAMETER_SET: u8 = 33;
+pub const NAL_UNIT_TYPE_PICTURE_PARAMETER_SET: u8 = 34;
 
 // ITU-T H.265, 11/2019, 7.3.1.1
 pub struct NALUnit<T> {

--- a/h265/src/picture_parameter_set.rs
+++ b/h265/src/picture_parameter_set.rs
@@ -1,0 +1,203 @@
+use super::{decode, encode, syntax_elements::*, Bitstream, BitstreamWriter, Decode, Encode};
+use std::io;
+
+// ITU-T H.265, 11/2019 7.3.2.3.1
+#[derive(Debug, Default)]
+pub struct PictureParameterSet {
+    pub pps_pic_parameter_set_id: UE,
+    pub pps_seq_parameter_set_id: UE,
+    pub dependent_slice_segments_enabled_flag: U1,
+    pub output_flag_present_flag: U1,
+    pub num_extra_slice_header_bits: U3,
+    pub sign_data_hiding_enabled_flag: U1,
+    pub cabac_init_present_flag: U1,
+    pub num_ref_idx_l0_default_active_minus1: UE,
+    pub num_ref_idx_l1_default_active_minus1: UE,
+    pub init_qp_minus26: SE,
+    pub constrained_intra_pred_flag: U1,
+    pub transform_skip_enabled_flag: U1,
+    pub cu_qp_delta_enabled_flag: U1,
+
+    // if( cu_qp_delta_enabled_flag )
+    pub diff_cu_qp_delta_depth: UE,
+
+    pub pps_cb_qp_offset: SE,
+    pub pps_cr_qp_offset: SE,
+    pub pps_slice_chroma_qp_offsets_present_flag: U1,
+    pub weighted_pred_flag: U1,
+    pub weighted_bipred_flag: U1,
+    pub transquant_bypass_enabled_flag: U1,
+    pub tiles_enabled_flag: U1,
+    pub entropy_coding_sync_enabled_flag: U1,
+
+    // if( tiles_enabled_flag ) {
+    pub num_tile_columns_minus1: UE,
+    pub num_tile_rows_minus1: UE,
+    pub uniform_spacing_flag: U1,
+    //   if( !uniform_spacing_flag ) {
+    //     for( i = 0; i < num_tile_columns_minus1; i++ )
+    pub column_width_minus1: Vec<UE>,
+    //     for( i = 0; i < num_tile_rows_minus1; i++ )
+    pub row_height_minus1: Vec<UE>,
+    //   }
+    pub loop_filter_across_tiles_enabled_flag: U1,
+    // }
+
+    // the remaining bits whose fields we don't currently support parsing
+    pub remaining_bits: Vec<U1>,
+}
+
+impl Decode for PictureParameterSet {
+    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+        let mut ret = Self::default();
+
+        decode!(
+            bs,
+            &mut ret.pps_pic_parameter_set_id,
+            &mut ret.pps_seq_parameter_set_id,
+            &mut ret.dependent_slice_segments_enabled_flag,
+            &mut ret.output_flag_present_flag,
+            &mut ret.num_extra_slice_header_bits,
+            &mut ret.sign_data_hiding_enabled_flag,
+            &mut ret.cabac_init_present_flag,
+            &mut ret.num_ref_idx_l0_default_active_minus1,
+            &mut ret.num_ref_idx_l1_default_active_minus1,
+            &mut ret.init_qp_minus26,
+            &mut ret.constrained_intra_pred_flag,
+            &mut ret.transform_skip_enabled_flag,
+            &mut ret.cu_qp_delta_enabled_flag
+        )?;
+
+        if ret.cu_qp_delta_enabled_flag.0 != 0 {
+            decode!(bs, &mut ret.diff_cu_qp_delta_depth)?;
+        }
+
+        decode!(
+            bs,
+            &mut ret.pps_cb_qp_offset,
+            &mut ret.pps_cr_qp_offset,
+            &mut ret.pps_slice_chroma_qp_offsets_present_flag,
+            &mut ret.weighted_pred_flag,
+            &mut ret.weighted_bipred_flag,
+            &mut ret.transquant_bypass_enabled_flag,
+            &mut ret.tiles_enabled_flag,
+            &mut ret.entropy_coding_sync_enabled_flag
+        )?;
+
+        if ret.tiles_enabled_flag.0 != 0 {
+            decode!(
+                bs,
+                &mut ret.num_tile_columns_minus1,
+                &mut ret.num_tile_rows_minus1,
+                &mut ret.uniform_spacing_flag
+            )?;
+            if ret.uniform_spacing_flag.0 != 0 {
+                for _ in 0..ret.num_tile_columns_minus1.0 {
+                    ret.column_width_minus1.push(UE::decode(bs)?);
+                }
+                for _ in 0..ret.num_tile_rows_minus1.0 {
+                    ret.row_height_minus1.push(UE::decode(bs)?);
+                }
+            }
+            decode!(bs, &mut ret.loop_filter_across_tiles_enabled_flag)?;
+        }
+
+        ret.remaining_bits = bs.bits().map(|b| U1(b as _)).collect();
+
+        Ok(ret)
+    }
+}
+
+impl Encode for PictureParameterSet {
+    fn encode<T: io::Write>(&self, bs: &mut BitstreamWriter<T>) -> io::Result<()> {
+        encode!(
+            bs,
+            &self.pps_pic_parameter_set_id,
+            &self.pps_seq_parameter_set_id,
+            &self.dependent_slice_segments_enabled_flag,
+            &self.output_flag_present_flag,
+            &self.num_extra_slice_header_bits,
+            &self.sign_data_hiding_enabled_flag,
+            &self.cabac_init_present_flag,
+            &self.num_ref_idx_l0_default_active_minus1,
+            &self.num_ref_idx_l1_default_active_minus1,
+            &self.init_qp_minus26,
+            &self.constrained_intra_pred_flag,
+            &self.transform_skip_enabled_flag,
+            &self.cu_qp_delta_enabled_flag
+        )?;
+
+        if self.cu_qp_delta_enabled_flag.0 != 0 {
+            encode!(bs, &self.diff_cu_qp_delta_depth)?;
+        }
+
+        encode!(
+            bs,
+            &self.pps_cb_qp_offset,
+            &self.pps_cr_qp_offset,
+            &self.pps_slice_chroma_qp_offsets_present_flag,
+            &self.weighted_pred_flag,
+            &self.weighted_bipred_flag,
+            &self.transquant_bypass_enabled_flag,
+            &self.tiles_enabled_flag,
+            &self.entropy_coding_sync_enabled_flag
+        )?;
+
+        if self.tiles_enabled_flag.0 != 0 {
+            encode!(bs, &self.num_tile_columns_minus1, &self.num_tile_rows_minus1, &self.uniform_spacing_flag)?;
+            if self.uniform_spacing_flag.0 != 0 {
+                encode!(bs, &self.column_width_minus1, &self.row_height_minus1)?;
+            }
+            encode!(bs, &self.loop_filter_across_tiles_enabled_flag)?;
+        }
+
+        self.remaining_bits.encode(bs)?;
+
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_picture_parameter_set() {
+        let data = [0xc0, 0xf2, 0xc6, 0x8d, 0x09, 0xc0, 0xa0, 0x14, 0x7b, 0x24];
+        let mut bs = Bitstream::new(data.iter());
+
+        let pps = PictureParameterSet::decode(&mut bs).unwrap();
+
+        assert_eq!(pps.pps_pic_parameter_set_id.0, 0);
+        assert_eq!(pps.pps_seq_parameter_set_id.0, 0);
+        assert_eq!(pps.dependent_slice_segments_enabled_flag.0, 0);
+        assert_eq!(pps.output_flag_present_flag.0, 0);
+        assert_eq!(pps.num_extra_slice_header_bits.0, 0);
+        assert_eq!(pps.sign_data_hiding_enabled_flag.0, 0);
+        assert_eq!(pps.cabac_init_present_flag.0, 1);
+        assert_eq!(pps.num_ref_idx_l0_default_active_minus1.0, 0);
+        assert_eq!(pps.num_ref_idx_l1_default_active_minus1.0, 0);
+        assert_eq!(pps.init_qp_minus26.0, 0);
+        assert_eq!(pps.constrained_intra_pred_flag.0, 0);
+        assert_eq!(pps.transform_skip_enabled_flag.0, 0);
+        assert_eq!(pps.cu_qp_delta_enabled_flag.0, 1);
+        assert_eq!(pps.diff_cu_qp_delta_depth.0, 2);
+        assert_eq!(pps.pps_cb_qp_offset.0, -6);
+        assert_eq!(pps.pps_cr_qp_offset.0, -6);
+        assert_eq!(pps.pps_slice_chroma_qp_offsets_present_flag.0, 0);
+        assert_eq!(pps.weighted_pred_flag.0, 0);
+        assert_eq!(pps.weighted_bipred_flag.0, 0);
+        assert_eq!(pps.transquant_bypass_enabled_flag.0, 0);
+        assert_eq!(pps.tiles_enabled_flag.0, 1);
+        assert_eq!(pps.entropy_coding_sync_enabled_flag.0, 0);
+        assert_eq!(pps.num_tile_columns_minus1.0, 2);
+        assert_eq!(pps.num_tile_rows_minus1.0, 0);
+        assert_eq!(pps.uniform_spacing_flag.0, 0);
+
+        assert_eq!(bs.next_bits(1), None);
+
+        let mut round_trip = Vec::new();
+        pps.encode(&mut BitstreamWriter::new(&mut round_trip)).unwrap();
+        assert_eq!(round_trip, data);
+    }
+}

--- a/h265/src/profile_tier_level.rs
+++ b/h265/src/profile_tier_level.rs
@@ -1,4 +1,4 @@
-use super::{decode, syntax_elements::*, Bitstream};
+use super::{decode, encode, syntax_elements::*, Bitstream, BitstreamWriter, Decode, Encode};
 use std::io;
 
 #[derive(Debug, Default)]
@@ -11,7 +11,12 @@ pub struct ProfileTierLevel {
     pub general_profile_compatibility_flags: U32,
     pub general_constraint_flags: U48,
     pub general_level_idc: U8,
+
+    pub sub_layer_profile_present_flag: Vec<U1>,
+    pub sub_layer_level_present_flag: Vec<U1>,
+
     // TODO: expose sub-layer info?
+    pub sublayer_info_bits: Vec<U1>,
 }
 
 impl ProfileTierLevel {
@@ -29,28 +34,48 @@ impl ProfileTierLevel {
             &mut ret.general_level_idc
         )?;
 
-        let mut sub_layer_profile_present_flag = vec![];
-        let mut sub_layer_level_present_flag = vec![];
         for _ in 0..max_num_sub_layers_minus1 {
-            sub_layer_profile_present_flag.push(bs.read_bits(1)?);
-            sub_layer_level_present_flag.push(bs.read_bits(1)?);
+            ret.sub_layer_profile_present_flag.push(U1::decode(bs)?);
+            ret.sub_layer_level_present_flag.push(U1::decode(bs)?);
         }
 
         if max_num_sub_layers_minus1 > 0 {
             for _ in max_num_sub_layers_minus1..8 {
-                bs.read_bits(2)?;
+                ret.sublayer_info_bits.extend(bs.bits().take(2).map(|b| U1(b as _)));
             }
         }
 
         for i in 0..max_num_sub_layers_minus1 {
-            if sub_layer_profile_present_flag[i as usize] != 0 {
-                bs.read_bits(88)?;
+            if ret.sub_layer_profile_present_flag[i as usize].0 != 0 {
+                ret.sublayer_info_bits.extend(bs.bits().take(88).map(|b| U1(b as _)));
             }
-            if sub_layer_profile_present_flag[i as usize] != 0 {
-                bs.read_bits(8)?;
+            if ret.sub_layer_level_present_flag[i as usize].0 != 0 {
+                ret.sublayer_info_bits.extend(bs.bits().take(8).map(|b| U1(b as _)));
             }
         }
 
         Ok(ret)
+    }
+
+    pub fn encode<T: io::Write>(&self, bs: &mut BitstreamWriter<T>, profile_present_flag: u8, max_num_sub_layers_minus1: u8) -> io::Result<()> {
+        if profile_present_flag != 0 {
+            encode!(bs, &self.general_profile_space, &self.general_tier_flag, &self.general_profile_idc)?;
+        }
+
+        encode!(
+            bs,
+            &self.general_profile_compatibility_flags,
+            &self.general_constraint_flags,
+            &self.general_level_idc
+        )?;
+
+        for i in 0..max_num_sub_layers_minus1 {
+            self.sub_layer_profile_present_flag[i as usize].encode(bs)?;
+            self.sub_layer_level_present_flag[i as usize].encode(bs)?;
+        }
+
+        self.sublayer_info_bits.encode(bs)?;
+
+        Ok(())
     }
 }

--- a/h265/src/sequence_parameter_set.rs
+++ b/h265/src/sequence_parameter_set.rs
@@ -684,5 +684,26 @@ mod test {
             sps.encode(&mut BitstreamWriter::new(&mut round_trip)).unwrap();
             assert_eq!(round_trip, data);
         }
+
+        {
+            let data = vec![
+                0x02, 0x01, 0x60, 0x00, 0x00, 0x00, 0x80, 0x00, 0x00, 0x00, 0x00, 0x00, 0xba, 0x00, 0x00, 0xa0, 0x00, 0xf0, 0x08, 0x00, 0x43, 0x85, 0xde, 0x49,
+                0x32, 0x8c, 0x04, 0x04, 0x00, 0x00, 0x0f, 0xa4, 0x00, 0x01, 0xd4, 0xc0, 0x20,
+            ];
+
+            let mut bs = Bitstream::new(data.iter());
+
+            let sps = SequenceParameterSet::decode(&mut bs).unwrap();
+
+            assert_eq!(0, sps.sps_video_parameter_set_id.0);
+            assert_eq!(7680, sps.pic_width_in_luma_samples.0);
+            assert_eq!(4320, sps.pic_height_in_luma_samples.0);
+
+            assert_eq!(bs.next_bits(1), None);
+
+            let mut round_trip = Vec::new();
+            sps.encode(&mut BitstreamWriter::new(&mut round_trip)).unwrap();
+            assert_eq!(round_trip, data);
+        }
     }
 }


### PR DESCRIPTION
* Adds a function for iterating through H264/H265 NALUs as they're read by an `io::Read`.
* Adds the `Encode` trait, which enables encoding of syntax elements and structures that implement it.
* Implements the `Encode` trait for H265 PPS and SPS, ensuring that decoding and re-encoding them is a lossless operation. This is useful when you need to modify a PPS or SPS and re-encode it.