### PR TITLE
add rfc6381 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,5 @@ members = [
     "mpegts-segmenter",
     "mpeg4",
     "qtff",
+    "rfc6381"
 ]

--- a/h264/src/nal_unit.rs
+++ b/h264/src/nal_unit.rs
@@ -18,6 +18,17 @@ pub struct NALUnit<T> {
     pub rbsp_byte: RBSP<T>,
 }
 
+impl<T: Clone> Clone for NALUnit<T> {
+    fn clone(&self) -> Self {
+        Self {
+            forbidden_zero_bit: self.forbidden_zero_bit.clone(),
+            nal_ref_idc: self.nal_ref_idc.clone(),
+            nal_unit_type: self.nal_unit_type.clone(),
+            rbsp_byte: self.rbsp_byte.clone(),
+        }
+    }
+}
+
 pub struct RBSP<T> {
     inner: T,
     zeros: usize,
@@ -30,6 +41,15 @@ impl<T> RBSP<T> {
 
     pub fn into_inner(self) -> T {
         self.inner
+    }
+}
+
+impl<T: Clone> Clone for RBSP<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            zeros: self.zeros,
+        }
     }
 }
 

--- a/h265/src/nal_unit.rs
+++ b/h265/src/nal_unit.rs
@@ -32,6 +32,15 @@ pub struct NALUnit<RBSP> {
     pub rbsp_byte: RBSP,
 }
 
+impl<RBSP: Clone> Clone for NALUnit<RBSP> {
+    fn clone(&self) -> Self {
+        Self {
+            nal_unit_header: self.nal_unit_header.clone(),
+            rbsp_byte: self.rbsp_byte.clone(),
+        }
+    }
+}
+
 impl<'a, T: Iterator<Item = &'a u8>> NALUnit<RBSP<T>> {
     pub fn decode(mut bs: Bitstream<T>) -> io::Result<Self> {
         Ok(Self {
@@ -51,7 +60,7 @@ impl<RBSP: IntoIterator<Item = u8>> NALUnit<RBSP> {
 }
 
 // ITU-T H.265, 11/2019, 7.3.1.1
-#[derive(Default)]
+#[derive(Clone, Default)]
 pub struct NALUnitHeader {
     pub forbidden_zero_bit: F1,
     pub nal_unit_type: U6,

--- a/mpegts-segmenter/Cargo.toml
+++ b/mpegts-segmenter/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2018"
 mpeg2 = { path = "../mpeg2" }
 h264 = { path = "../h264" }
 h265 = { path = "../h265" }
+rfc6381 = { path = "../rfc6381" }
 tokio = { version = "0.2.13", features = ["macros", "blocking", "io-util", "fs"] }
 simple-error = "0.2.1"
 async-trait = "0.1.35"

--- a/mpegts-segmenter/src/analyzer.rs
+++ b/mpegts-segmenter/src/analyzer.rs
@@ -163,8 +163,8 @@ impl Stream {
                         h264::NAL_UNIT_TYPE_SEQUENCE_PARAMETER_SET => {
                             let bs = h264::Bitstream::new(nalu);
                             let mut nalu = h264::NALUnit::decode(bs)?;
+                            *rfc6381_codec = rfc6381::codec_from_h264_nalu(nalu.clone());
                             let mut rbsp = h264::Bitstream::new(&mut nalu.rbsp_byte);
-                            let leading_bytes = require_with!(rbsp.next_bits(24), "unable to get leading SPS RBSP bytes");
                             let sps = h264::SequenceParameterSet::decode(&mut rbsp)?;
                             *is_interlaced = sps.frame_mbs_only_flag.0 == 0;
                             *width = sps.frame_cropping_rectangle_width() as _;
@@ -176,12 +176,6 @@ impl Stream {
                                 0 => 0.0,
                                 num_units_in_tick @ _ => (sps.vui_parameters.time_scale.0 as f64 / (2.0 * num_units_in_tick as f64) * 100.0).round() / 100.0,
                             };
-                            *rfc6381_codec = Some(format!(
-                                "avc1.{:02x}{:02x}{:02x}",
-                                (leading_bytes >> 16) as u8,
-                                (leading_bytes >> 8) as u8,
-                                leading_bytes as u8,
-                            ))
                         }
                         _ => {}
                     }
@@ -211,6 +205,7 @@ impl Stream {
                         h265::NAL_UNIT_TYPE_SPS_NUT => {
                             let bs = h265::Bitstream::new(nalu);
                             let mut nalu = h265::NALUnit::decode(bs)?;
+                            *rfc6381_codec = rfc6381::codec_from_h265_nalu(nalu.clone());
                             let mut rbsp = h265::Bitstream::new(&mut nalu.rbsp_byte);
                             let sps = h265::SequenceParameterSet::decode(&mut rbsp)?;
                             *width = sps.pic_width_in_luma_samples.0 as _;
@@ -224,36 +219,6 @@ impl Stream {
                                     num_units_in_tick @ _ => (sps.vui_parameters.vui_time_scale.0 as f64 / num_units_in_tick as f64 * 100.0).round() / 100.0,
                                 };
                             }
-                            let ptl = &sps.profile_tier_level;
-                            *rfc6381_codec = Some(format!(
-                                "hvc1.{}{}.{:X}.{}{}.{}",
-                                if ptl.general_profile_space.0 > 0 {
-                                    (('A' as u8 + (ptl.general_profile_space.0 - 1)) as char).to_string()
-                                } else {
-                                    "".to_string()
-                                },
-                                ptl.general_profile_idc.0,
-                                ptl.general_profile_compatibility_flags.0.reverse_bits(),
-                                match ptl.general_tier_flag.0 {
-                                    0 => 'L',
-                                    _ => 'H',
-                                },
-                                ptl.general_level_idc.0,
-                                {
-                                    let mut constraint_bytes = vec![
-                                        (ptl.general_constraint_flags.0 >> 40) as u8,
-                                        (ptl.general_constraint_flags.0 >> 32) as u8,
-                                        (ptl.general_constraint_flags.0 >> 24) as u8,
-                                        (ptl.general_constraint_flags.0 >> 16) as u8,
-                                        (ptl.general_constraint_flags.0 >> 8) as u8,
-                                        (ptl.general_constraint_flags.0 >> 0) as u8,
-                                    ];
-                                    while constraint_bytes.len() > 1 && constraint_bytes.last().copied() == Some(0) {
-                                        constraint_bytes.pop();
-                                    }
-                                    constraint_bytes.into_iter().map(|b| format!("{:02X}", b)).collect::<Vec<_>>().join(".")
-                                },
-                            ))
                         }
                         h265::NAL_UNIT_TYPE_VPS_NUT => {
                             let bs = h265::Bitstream::new(nalu);

--- a/rfc6381/Cargo.toml
+++ b/rfc6381/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "rfc6381"
+version = "0.1.0"
+edition = "2018"
+
+[features]
+default = []
+ffmpeg = ["ffmpeg-sys"]
+
+[dependencies]
+h264 = { path = "../h264" }
+h265 = { path = "../h265" }
+ffmpeg-sys = {version = "4.0.2", git = "https://github.com/meh/rust-ffmpeg-sys", default-features = false, features = ["avcodec"], optional = true}

--- a/rfc6381/README.md
+++ b/rfc6381/README.md
@@ -1,0 +1,3 @@
+# rfc6381
+
+This is a crate that can be used to build RFC-6318 codec strings such as those used for HLS manifests.

--- a/rfc6381/src/lib.rs
+++ b/rfc6381/src/lib.rs
@@ -1,0 +1,87 @@
+pub fn codec_from_h264_nalu<'a, T: Iterator<Item = &'a u8>>(mut nalu: h264::NALUnit<T>) -> Option<String> {
+    if nalu.nal_unit_type.0 == h264::NAL_UNIT_TYPE_SEQUENCE_PARAMETER_SET {
+        let mut rbsp = h264::Bitstream::new(&mut nalu.rbsp_byte);
+        let leading_bytes = rbsp.next_bits(24)?;
+        return Some(format!(
+            "avc1.{:02x}{:02x}{:02x}",
+            (leading_bytes >> 16) as u8,
+            (leading_bytes >> 8) as u8,
+            leading_bytes as u8,
+        ));
+    }
+    None
+}
+
+pub fn codec_from_h265_nalu<'a, T: Iterator<Item = &'a u8>>(mut nalu: h265::NALUnit<h265::RBSP<T>>) -> Option<String> {
+    use h265::Decode;
+    if nalu.nal_unit_header.nal_unit_type.0 == h265::NAL_UNIT_TYPE_SPS_NUT {
+        let mut rbsp = h265::Bitstream::new(&mut nalu.rbsp_byte);
+        let sps = h265::SequenceParameterSet::decode(&mut rbsp).ok()?;
+        let ptl = &sps.profile_tier_level;
+        return Some(format!(
+            "hvc1.{}{}.{:X}.{}{}.{}",
+            if ptl.general_profile_space.0 > 0 {
+                (('A' as u8 + (ptl.general_profile_space.0 - 1)) as char).to_string()
+            } else {
+                "".to_string()
+            },
+            ptl.general_profile_idc.0,
+            ptl.general_profile_compatibility_flags.0.reverse_bits(),
+            match ptl.general_tier_flag.0 {
+                0 => 'L',
+                _ => 'H',
+            },
+            ptl.general_level_idc.0,
+            {
+                let mut constraint_bytes = vec![
+                    (ptl.general_constraint_flags.0 >> 40) as u8,
+                    (ptl.general_constraint_flags.0 >> 32) as u8,
+                    (ptl.general_constraint_flags.0 >> 24) as u8,
+                    (ptl.general_constraint_flags.0 >> 16) as u8,
+                    (ptl.general_constraint_flags.0 >> 8) as u8,
+                    (ptl.general_constraint_flags.0 >> 0) as u8,
+                ];
+                while constraint_bytes.len() > 1 && constraint_bytes.last().copied() == Some(0) {
+                    constraint_bytes.pop();
+                }
+                constraint_bytes.into_iter().map(|b| format!("{:02X}", b)).collect::<Vec<_>>().join(".")
+            },
+        ));
+    }
+    None
+}
+
+#[cfg(feature = "ffmpeg")]
+pub fn codec_from_ffmpeg_codec_context(codec: &ffmpeg_sys::AVCodecContext) -> Option<String> {
+    use ffmpeg_sys::*;
+    match codec.codec_id {
+        AVCodecID::AV_CODEC_ID_AAC => Some(format!("mp4a.40.{}", codec.profile + 1)),
+        AVCodecID::AV_CODEC_ID_H264 => {
+            if codec.extradata_size > 0 {
+                let extradata = unsafe { std::slice::from_raw_parts(codec.extradata, codec.extradata_size as _) };
+                for nalu in h264::iterate_annex_b(&extradata) {
+                    let bs = h264::Bitstream::new(nalu);
+                    let nalu = h264::NALUnit::decode(bs).ok()?;
+                    if let Some(codec) = codec_from_h264_nalu(nalu) {
+                        return Some(codec);
+                    }
+                }
+            }
+            None
+        }
+        AVCodecID::AV_CODEC_ID_HEVC => {
+            if codec.extradata_size > 0 {
+                let extradata = unsafe { std::slice::from_raw_parts(codec.extradata, codec.extradata_size as _) };
+                for nalu in h265::iterate_annex_b(&extradata) {
+                    let bs = h265::Bitstream::new(nalu);
+                    let nalu = h265::NALUnit::decode(bs).ok()?;
+                    if let Some(codec) = codec_from_h265_nalu(nalu) {
+                        return Some(codec);
+                    }
+                }
+            }
+            None
+        }
+        _ => None,
+    }
+}


### PR DESCRIPTION
This moves all of our RFC-6381 logic to a new crate, making it more re-usable.