### PR TITLE
iterate over u8 instead of &u8

### DIFF
--- a/h264/src/lib.rs
+++ b/h264/src/lib.rs
@@ -205,7 +205,7 @@ impl AccessUnitCounter {
             1 | 2 => {
                 if self.maybe_start_new_access_unit {
                     if let Some(sps) = &self.sps {
-                        let bs = Bitstream::new(nalu);
+                        let bs = Bitstream::new(nalu.iter().copied());
                         let mut nalu = NALUnit::decode(bs)?;
                         let mut rbsp = Bitstream::new(&mut nalu.rbsp_byte);
                         let slice_header = SliceHeader::decode(&mut rbsp, sps)?;
@@ -229,7 +229,7 @@ impl AccessUnitCounter {
 
         match nalu_type {
             NAL_UNIT_TYPE_SEQUENCE_PARAMETER_SET => {
-                let bs = Bitstream::new(nalu);
+                let bs = Bitstream::new(nalu.iter().copied());
                 let mut nalu = NALUnit::decode(bs)?;
                 let mut rbsp = Bitstream::new(&mut nalu.rbsp_byte);
                 let sps = SequenceParameterSet::decode(&mut rbsp)?;

--- a/h264/src/nal_unit.rs
+++ b/h264/src/nal_unit.rs
@@ -53,8 +53,8 @@ impl<T: Clone> Clone for RBSP<T> {
     }
 }
 
-impl<'a, T: Iterator<Item = &'a u8>> Iterator for &mut RBSP<T> {
-    type Item = &'a u8;
+impl<T: Iterator<Item = u8>> Iterator for &mut RBSP<T> {
+    type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -138,7 +138,7 @@ impl<'a, T: Iterator<Item = u8>> Iterator for &mut EmulationPrevention<T> {
     }
 }
 
-impl<'a, T: Iterator<Item = &'a u8>> NALUnit<T> {
+impl<T: Iterator<Item = u8>> NALUnit<T> {
     pub fn decode(mut bs: Bitstream<T>) -> io::Result<Self> {
         let mut forbidden_zero_bit = F1::default();
         let mut nal_ref_idc = U2::default();

--- a/h264/src/sequence_parameter_set.rs
+++ b/h264/src/sequence_parameter_set.rs
@@ -163,7 +163,7 @@ impl SequenceParameterSet {
 }
 
 impl Decode for SequenceParameterSet {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         let mut ret = Self::default();
 
         decode!(
@@ -316,7 +316,7 @@ pub struct VUIParameters {
 pub const ASPECT_RATIO_IDC_EXTENDED_SAR: u8 = 255;
 
 impl Decode for VUIParameters {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         let mut ret = Self::default();
 
         decode!(bs, &mut ret.aspect_ratio_info_present_flag)?;
@@ -372,7 +372,7 @@ mod test {
 
     #[test]
     fn test_sequence_parameter_set() {
-        let mut bs = Bitstream::new(&[
+        let mut bs = Bitstream::new(vec![
             0x4d, 0x40, 0x1f, 0xec, 0xa0, 0x28, 0x02, 0xdd, 0x80, 0xb5, 0x01, 0x01, 0x01, 0x40, 0x00, 0x00, 0x00, 0x40, 0x00, 0x05, 0xdc, 0x03, 0xc6, 0x0c,
             0x65, 0x80,
         ]);

--- a/h264/src/slice_header.rs
+++ b/h264/src/slice_header.rs
@@ -14,7 +14,7 @@ pub struct SliceHeader {
 }
 
 impl SliceHeader {
-    pub fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>, sps: &SequenceParameterSet) -> io::Result<Self> {
+    pub fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>, sps: &SequenceParameterSet) -> io::Result<Self> {
         let mut ret = Self::default();
 
         decode!(bs, &mut ret.first_mb_in_slice, &mut ret.slice_type, &mut ret.pic_parameter_set_id)?;

--- a/h265/src/lib.rs
+++ b/h265/src/lib.rs
@@ -49,14 +49,14 @@ impl AccessUnitCounter {
     pub fn count_nalu<T: AsRef<[u8]>>(&mut self, nalu: T) -> io::Result<()> {
         let nalu = nalu.as_ref();
 
-        let mut bs = Bitstream::new(nalu);
+        let mut bs = Bitstream::new(nalu.iter().copied());
         let header = NALUnitHeader::decode(&mut bs)?;
 
         // ITU-T H.265, 11/2019, 7.4.2.4.4
         match header.nal_unit_type.0 {
             0..=9 | 16..=21 => {
                 if self.maybe_start_new_access_unit {
-                    let bs = Bitstream::new(nalu);
+                    let bs = Bitstream::new(nalu.iter().copied());
                     let mut nalu = NALUnit::decode(bs)?;
                     let mut rbsp = Bitstream::new(&mut nalu.rbsp_byte);
                     let first_slice_segment_in_pic_flag = U1::decode(&mut rbsp)?;

--- a/h265/src/nal_unit.rs
+++ b/h265/src/nal_unit.rs
@@ -41,7 +41,7 @@ impl<RBSP: Clone> Clone for NALUnit<RBSP> {
     }
 }
 
-impl<'a, T: Iterator<Item = &'a u8>> NALUnit<RBSP<T>> {
+impl<T: Iterator<Item = u8>> NALUnit<RBSP<T>> {
     pub fn decode(mut bs: Bitstream<T>) -> io::Result<Self> {
         Ok(Self {
             nal_unit_header: NALUnitHeader::decode(&mut bs)?,
@@ -69,7 +69,7 @@ pub struct NALUnitHeader {
 }
 
 impl Decode for NALUnitHeader {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         let mut ret = Self::default();
 
         decode!(

--- a/h265/src/picture_parameter_set.rs
+++ b/h265/src/picture_parameter_set.rs
@@ -99,7 +99,7 @@ impl PictureParameterSet {
 }
 
 impl Decode for PictureParameterSet {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         let mut ret = Self::default();
 
         decode!(
@@ -293,8 +293,8 @@ mod test {
     #[test]
     fn test_picture_parameter_set() {
         {
-            let data = [0xc0, 0xf2, 0xc6, 0x8d, 0x09, 0xc0, 0xa0, 0x14, 0x7b, 0x24];
-            let mut bs = Bitstream::new(data.iter());
+            let data = vec![0xc0, 0xf2, 0xc6, 0x8d, 0x09, 0xc0, 0xa0, 0x14, 0x7b, 0x24];
+            let mut bs = Bitstream::new(data.iter().copied());
 
             let pps = PictureParameterSet::decode(&mut bs).unwrap();
 
@@ -332,8 +332,8 @@ mod test {
         }
 
         {
-            let data = [0xc1, 0x62, 0x4f, 0x08, 0x20, 0x26, 0x4c, 0x90];
-            let mut bs = Bitstream::new(data.iter());
+            let data = vec![0xc1, 0x62, 0x4f, 0x08, 0x20, 0x26, 0x4c, 0x90];
+            let mut bs = Bitstream::new(data.iter().copied());
 
             let pps = PictureParameterSet::decode(&mut bs).unwrap();
 

--- a/h265/src/profile_tier_level.rs
+++ b/h265/src/profile_tier_level.rs
@@ -20,7 +20,7 @@ pub struct ProfileTierLevel {
 }
 
 impl ProfileTierLevel {
-    pub fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>, profile_present_flag: u8, max_num_sub_layers_minus1: u8) -> io::Result<Self> {
+    pub fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>, profile_present_flag: u8, max_num_sub_layers_minus1: u8) -> io::Result<Self> {
         let mut ret = Self::default();
 
         if profile_present_flag != 0 {

--- a/h265/src/sequence_parameter_set.rs
+++ b/h265/src/sequence_parameter_set.rs
@@ -9,7 +9,7 @@ pub struct SequenceParameterSetSubLayerOrderingInfo {
 }
 
 impl Decode for SequenceParameterSetSubLayerOrderingInfo {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         Ok(Self {
             sps_max_dec_pic_buffering_minus1: UE::decode(bs)?,
             sps_max_num_reorder_pics: UE::decode(bs)?,
@@ -46,7 +46,7 @@ pub struct ShortTermRefPicSet {
 
 #[allow(non_snake_case)]
 impl ShortTermRefPicSet {
-    pub fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>, st_rps_idx: u64) -> io::Result<Self> {
+    pub fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>, st_rps_idx: u64) -> io::Result<Self> {
         let mut ret = Self::default();
 
         if st_rps_idx != 0 {
@@ -247,7 +247,7 @@ impl SequenceParameterSet {
 }
 
 impl Decode for SequenceParameterSet {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         let mut ret = Self::default();
 
         decode!(
@@ -542,7 +542,7 @@ pub struct VUIParameters {
 pub const ASPECT_RATIO_IDC_EXTENDED_SAR: u8 = 255;
 
 impl Decode for VUIParameters {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         let mut ret = Self::default();
 
         decode!(bs, &mut ret.aspect_ratio_info_present_flag)?;
@@ -683,7 +683,7 @@ mod test {
                 0x01, 0x01, 0x60, 0x00, 0x00, 0x00, 0xb0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x96, 0xa0, 0x02, 0x80, 0x80, 0x2d, 0x16, 0x20, 0x5e, 0xe4, 0x59, 0x14,
                 0xbf, 0xf2, 0xe7, 0xf1, 0x3f, 0xac, 0x05, 0xa8, 0x10, 0x10, 0x10, 0x04,
             ];
-            let mut bs = Bitstream::new(data.iter());
+            let mut bs = Bitstream::new(data.iter().copied());
 
             let sps = SequenceParameterSet::decode(&mut bs).unwrap();
 
@@ -721,7 +721,7 @@ mod test {
                 0x01, 0x04, 0x08, 0x00, 0x00, 0x00, 0x9d, 0x08, 0x00, 0x00, 0x00, 0x00, 0x78, 0xb0, 0x02, 0x80, 0x80, 0x2d, 0x13, 0x65, 0x95, 0x9a, 0x49, 0x32,
                 0xbc, 0x05, 0xa0, 0x20, 0x00, 0x00, 0x7d, 0x20, 0x00, 0x1d, 0x4c, 0x01,
             ];
-            let mut bs = Bitstream::new(data.iter());
+            let mut bs = Bitstream::new(data.iter().copied());
 
             let sps = SequenceParameterSet::decode(&mut bs).unwrap();
 
@@ -762,7 +762,7 @@ mod test {
                 0x32, 0x8c, 0x04, 0x04, 0x00, 0x00, 0x0f, 0xa4, 0x00, 0x01, 0xd4, 0xc0, 0x20,
             ];
 
-            let mut bs = Bitstream::new(data.iter());
+            let mut bs = Bitstream::new(data.iter().copied());
 
             let sps = SequenceParameterSet::decode(&mut bs).unwrap();
 

--- a/h265/src/video_parameter_set.rs
+++ b/h265/src/video_parameter_set.rs
@@ -9,7 +9,7 @@ pub struct VideoParameterSetSubLayerOrderingInfo {
 }
 
 impl Decode for VideoParameterSetSubLayerOrderingInfo {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         Ok(Self {
             vps_max_dec_pic_buffering_minus1: UE::decode(bs)?,
             vps_max_num_reorder_pics: UE::decode(bs)?,
@@ -49,7 +49,7 @@ pub struct VideoParameterSet {
 }
 
 impl Decode for VideoParameterSet {
-    fn decode<'a, T: Iterator<Item = &'a u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
+    fn decode<T: Iterator<Item = u8>>(bs: &mut Bitstream<T>) -> io::Result<Self> {
         let mut ret = Self::default();
 
         decode!(
@@ -103,12 +103,9 @@ mod test {
 
     #[test]
     fn test_sequence_parameter_set() {
-        let mut bs = Bitstream::new(
-            [
-                0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x00, 0xb0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x96, 0x17, 0x02, 0x40,
-            ]
-            .iter(),
-        );
+        let mut bs = Bitstream::new(vec![
+            0x0c, 0x01, 0xff, 0xff, 0x01, 0x60, 0x00, 0x00, 0x00, 0xb0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x96, 0x17, 0x02, 0x40,
+        ]);
 
         let vps = VideoParameterSet::decode(&mut bs).unwrap();
 
@@ -116,12 +113,9 @@ mod test {
         assert_eq!(0xb00000000000, vps.profile_tier_level.general_constraint_flags.0);
         assert_eq!(0, vps.vps_timing_info_present_flag.0);
 
-        let mut bs = Bitstream::new(
-            [
-                0x0c, 0x01, 0xff, 0xff, 0x04, 0x08, 0x00, 0x00, 0x00, 0x9d, 0x08, 0x00, 0x00, 0x00, 0x00, 0x78, 0x95, 0x98, 0x09,
-            ]
-            .iter(),
-        );
+        let mut bs = Bitstream::new(vec![
+            0x0c, 0x01, 0xff, 0xff, 0x04, 0x08, 0x00, 0x00, 0x00, 0x9d, 0x08, 0x00, 0x00, 0x00, 0x00, 0x78, 0x95, 0x98, 0x09,
+        ]);
 
         let vps = VideoParameterSet::decode(&mut bs).unwrap();
 

--- a/mpegts-segmenter/src/analyzer.rs
+++ b/mpegts-segmenter/src/analyzer.rs
@@ -161,7 +161,7 @@ impl Stream {
                     let nalu_type = nalu[0] & h264::NAL_UNIT_TYPE_MASK;
                     match nalu_type {
                         h264::NAL_UNIT_TYPE_SEQUENCE_PARAMETER_SET => {
-                            let bs = h264::Bitstream::new(nalu);
+                            let bs = h264::Bitstream::new(nalu.iter().copied());
                             let mut nalu = h264::NALUnit::decode(bs)?;
                             *rfc6381_codec = rfc6381::codec_from_h264_nalu(nalu.clone());
                             let mut rbsp = h264::Bitstream::new(&mut nalu.rbsp_byte);
@@ -198,12 +198,12 @@ impl Stream {
 
                     access_unit_counter.count_nalu(&nalu)?;
 
-                    let mut bs = h265::Bitstream::new(nalu);
+                    let mut bs = h265::Bitstream::new(nalu.iter().copied());
                     let header = h265::NALUnitHeader::decode(&mut bs)?;
 
                     match header.nal_unit_type.0 {
                         h265::NAL_UNIT_TYPE_SPS_NUT => {
-                            let bs = h265::Bitstream::new(nalu);
+                            let bs = h265::Bitstream::new(nalu.iter().copied());
                             let mut nalu = h265::NALUnit::decode(bs)?;
                             *rfc6381_codec = rfc6381::codec_from_h265_nalu(nalu.clone());
                             let mut rbsp = h265::Bitstream::new(&mut nalu.rbsp_byte);
@@ -221,7 +221,7 @@ impl Stream {
                             }
                         }
                         h265::NAL_UNIT_TYPE_VPS_NUT => {
-                            let bs = h265::Bitstream::new(nalu);
+                            let bs = h265::Bitstream::new(nalu.iter().copied());
                             let mut nalu = h265::NALUnit::decode(bs)?;
                             let mut rbsp = h265::Bitstream::new(&mut nalu.rbsp_byte);
                             let vps = h265::VideoParameterSet::decode(&mut rbsp)?;

--- a/mpegts-segmenter/src/segmenter.rs
+++ b/mpegts-segmenter/src/segmenter.rs
@@ -114,7 +114,7 @@ impl<S: SegmentStorage> Segmenter<S> {
                                         Some(analyzer::Stream::HEVCVideo { .. }) => {
                                             use h264::Decode;
                                             for nalu in h265::iterate_annex_b(&payload) {
-                                                let mut bs = h265::Bitstream::new(nalu);
+                                                let mut bs = h265::Bitstream::new(nalu.iter().copied());
                                                 let header = h265::NALUnitHeader::decode(&mut bs)?;
                                                 if header.nuh_layer_id.0 == 0 {
                                                     match header.nal_unit_type.0 {

--- a/rfc6381/src/lib.rs
+++ b/rfc6381/src/lib.rs
@@ -1,4 +1,4 @@
-pub fn codec_from_h264_nalu<'a, T: Iterator<Item = &'a u8>>(mut nalu: h264::NALUnit<T>) -> Option<String> {
+pub fn codec_from_h264_nalu<T: Iterator<Item = u8>>(mut nalu: h264::NALUnit<T>) -> Option<String> {
     if nalu.nal_unit_type.0 == h264::NAL_UNIT_TYPE_SEQUENCE_PARAMETER_SET {
         let mut rbsp = h264::Bitstream::new(&mut nalu.rbsp_byte);
         let leading_bytes = rbsp.next_bits(24)?;
@@ -12,7 +12,7 @@ pub fn codec_from_h264_nalu<'a, T: Iterator<Item = &'a u8>>(mut nalu: h264::NALU
     None
 }
 
-pub fn codec_from_h265_nalu<'a, T: Iterator<Item = &'a u8>>(mut nalu: h265::NALUnit<h265::RBSP<T>>) -> Option<String> {
+pub fn codec_from_h265_nalu<T: Iterator<Item = u8>>(mut nalu: h265::NALUnit<h265::RBSP<T>>) -> Option<String> {
     use h265::Decode;
     if nalu.nal_unit_header.nal_unit_type.0 == h265::NAL_UNIT_TYPE_SPS_NUT {
         let mut rbsp = h265::Bitstream::new(&mut nalu.rbsp_byte);


### PR DESCRIPTION
This makes all of the H26X parsing use an iterator over `u8` instead of `&u8`. The rationale being:

1. It's more concise and eliminates lifetime parameters.
2. It facilitates using iterators that own data (which you can't do with `&u8` until GATs become real). So you can just `Bitstream::new(vec![])` for example, where previously you would have had to assign the vector to a temporary variable. Similarly this facilitates iterators that _generate_ data (which we don't have at the moment, but they might be useful for situations such as fuzz testing).

Because any iterator over `&u8` can be trivially turned into an iterator over `u8` with `.copied()`, there's no loss in functionality.