### PR TITLE
fix has_video

### DIFF
--- a/mpegts-segmenter/src/analyzer.rs
+++ b/mpegts-segmenter/src/analyzer.rs
@@ -458,39 +458,41 @@ impl Analyzer {
                     match &mut self.pids[pes.elementary_pid as usize] {
                         PIDState::PES { .. } => {}
                         state @ _ => {
-                            *state = PIDState::PES {
-                                stream: match pes.stream_type {
-                                    0x0f => Stream::ADTSAudio {
-                                        pes: pes::Stream::new(),
-                                        channel_count: 0,
-                                        sample_rate: 0,
-                                        sample_count: 0,
-                                        object_type_indication: 0x40,
-                                        rfc6381_codec: None,
-                                    },
-                                    0x1b => Stream::AVCVideo {
-                                        pes: pes::Stream::new(),
-                                        width: 0,
-                                        height: 0,
-                                        frame_rate: 0.0,
-                                        is_interlaced: false,
-                                        access_unit_counter: h264::AccessUnitCounter::new(),
-                                        rfc6381_codec: None,
-                                        last_vui_parameters: None,
-                                        last_timecode: None,
-                                        timecode: None,
-                                    },
-                                    0x24 => Stream::HEVCVideo {
-                                        pes: pes::Stream::new(),
-                                        width: 0,
-                                        height: 0,
-                                        frame_rate: 0.0,
-                                        access_unit_counter: h265::AccessUnitCounter::new(),
-                                        rfc6381_codec: None,
-                                    },
-                                    t @ _ => Stream::Other(t),
+                            let stream = match pes.stream_type {
+                                0x0f => Stream::ADTSAudio {
+                                    pes: pes::Stream::new(),
+                                    channel_count: 0,
+                                    sample_rate: 0,
+                                    sample_count: 0,
+                                    object_type_indication: 0x40,
+                                    rfc6381_codec: None,
                                 },
+                                0x1b => Stream::AVCVideo {
+                                    pes: pes::Stream::new(),
+                                    width: 0,
+                                    height: 0,
+                                    frame_rate: 0.0,
+                                    is_interlaced: false,
+                                    access_unit_counter: h264::AccessUnitCounter::new(),
+                                    rfc6381_codec: None,
+                                    last_vui_parameters: None,
+                                    last_timecode: None,
+                                    timecode: None,
+                                },
+                                0x24 => Stream::HEVCVideo {
+                                    pes: pes::Stream::new(),
+                                    width: 0,
+                                    height: 0,
+                                    frame_rate: 0.0,
+                                    access_unit_counter: h265::AccessUnitCounter::new(),
+                                    rfc6381_codec: None,
+                                },
+                                t @ _ => Stream::Other(t),
+                            };
+                            if stream.is_video() {
+                                self.has_video = true;
                             }
+                            *state = PIDState::PES { stream }
                         }
                     };
                 }
@@ -534,6 +536,7 @@ mod test {
             analyzer.flush().unwrap();
         }
 
+        assert_eq!(analyzer.has_video(), true);
         assert_eq!(
             analyzer.streams(),
             vec![
@@ -568,6 +571,7 @@ mod test {
             analyzer.flush().unwrap();
         }
 
+        assert_eq!(analyzer.has_video(), true);
         assert_eq!(
             analyzer.streams(),
             vec![
@@ -602,6 +606,7 @@ mod test {
             analyzer.flush().unwrap();
         }
 
+        assert_eq!(analyzer.has_video(), true);
         assert_eq!(
             analyzer.streams(),
             vec![
@@ -636,6 +641,7 @@ mod test {
             analyzer.flush().unwrap();
         }
 
+        assert_eq!(analyzer.has_video(), true);
         assert_eq!(
             analyzer.streams(),
             vec![
@@ -670,6 +676,7 @@ mod test {
             analyzer.flush().unwrap();
         }
 
+        assert_eq!(analyzer.has_video(), true);
         assert_eq!(
             analyzer.streams(),
             vec![

--- a/mpegts-segmenter/src/segmenter.rs
+++ b/mpegts-segmenter/src/segmenter.rs
@@ -299,7 +299,7 @@ mod test {
         }
 
         let segments = storage.segments();
-        assert_eq!(segments.len(), 4);
+        assert_eq!(segments.len(), 3);
         for (_, info) in segments {
             assert_eq!(info.streams.len(), 2);
             for stream in &info.streams {


### PR DESCRIPTION
`has_video` was never being written. This caused the segmenter to segment on _audio_ RAI bits because it didn't think the streams had video.