### PR TITLE
support empty adaptation field

### DIFF
--- a/mpegts-segmenter/src/segmenter.rs
+++ b/mpegts-segmenter/src/segmenter.rs
@@ -102,7 +102,7 @@ impl<S: SegmentStorage> Segmenter<S> {
                                 && (elapsed_seconds < -1.0 || elapsed_seconds >= self.config.min_segment_duration.as_secs_f64())
                             {
                                 // start a new segment if this is a keyframe
-                                if p.adaptation_field.map(|af| af.random_access_indicator).unwrap_or(false) {
+                                if p.adaptation_field.and_then(|af| af.random_access_indicator).unwrap_or(false) {
                                     true
                                 } else if let Some(payload) = p.payload {
                                     // some muxers don't set RAI bits. if possible, see if this


### PR DESCRIPTION
Relevant spec:

<img width="454" alt="Screen Shot 2021-01-10 at 4 37 07 PM" src="https://user-images.githubusercontent.com/1731074/104136113-2fdf5d00-5362-11eb-8ab6-bfb5d174ce37.png">

I didn't think zero length adaptation fields were valid but apparently they are. Some of our streams have these sometimes. Previously we would error out on them. Now we handle them correctly.