### PR TITLE
add h265-tile-join program

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "h264",
     "h265",
     "h265-tile-mux",
+    "h265-tile-join",
     "hmp",
     "macos/core-foundation",
     "macos/core-media",

--- a/h265-tile-join/Cargo.toml
+++ b/h265-tile-join/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "h265-tile-join"
+version = "0.1.0"
+edition = "2018"
+
+[features]
+default = []
+bin = ["clap"]
+
+[[bin]]
+name = "h265-tile-join"
+path = "src/main.rs"
+required-features = ["bin"]
+
+[dependencies]
+h265 = { path = "../h265" }
+clap = { version = "2.33.3", optional = true }

--- a/h265-tile-join/README.md
+++ b/h265-tile-join/README.md
@@ -1,0 +1,12 @@
+# h265-tile-join
+
+This program will combine multiple untiled videos into a single video via tiling.
+
+```
+cargo run --features bin -- -i ./test/tiles/*.h265 -o ./test/out.h265
+```
+
+Constraints:
+
+* All videos must be encoded using the same settings and have synchronized keyframes.
+* All tiles must have resolutions divisible by their CTB size except for the right/bottom-most tiles.

--- a/h265-tile-join/src/lib.rs
+++ b/h265-tile-join/src/lib.rs
@@ -1,0 +1,183 @@
+use h265::{
+    Bitstream, BitstreamWriter, Decode, EmulationPrevention, Encode, NALUnit, NALUnitHeader, PictureParameterSet, SequenceParameterSet, SliceSegmentHeader,
+};
+use std::{
+    collections::VecDeque,
+    io::{self, Write},
+};
+
+pub fn join<I, II, T, E, Iter, O>(inputs: II, mut output: O) -> Result<(), E>
+where
+    E: From<io::Error>,
+    T: AsRef<[u8]>,
+    I: IntoIterator<Item = Result<T, E>, IntoIter = Iter>,
+    II: IntoIterator<Item = I>,
+    Iter: Iterator<Item = Result<T, E>>,
+    O: Write,
+{
+    let mut inputs = inputs.into_iter().map(|input| Input::new(input.into_iter())).collect::<Result<Vec<_>, E>>()?;
+
+    let input_0_sps = inputs[0].sps.clone();
+    let mut sps = input_0_sps.clone();
+    sps.pic_width_in_luma_samples.0 = 0;
+    for input in &inputs {
+        sps.pic_width_in_luma_samples.0 += input.sps.pic_width_in_luma_samples.0;
+    }
+
+    let input_0_pps = inputs[0].pps.clone();
+    let mut pps = input_0_pps.clone();
+    pps.tiles_enabled_flag.0 = 1;
+    pps.num_tile_columns_minus1.0 = inputs.len() as u64 - 1;
+    pps.uniform_spacing_flag.0 = 1;
+
+    while let Some(nalu) = inputs[0].next_nalu() {
+        let nalu = nalu?;
+
+        let mut bs = Bitstream::new(nalu.iter().copied());
+        let nalu_header = NALUnitHeader::decode(&mut bs)?;
+
+        match nalu_header.nal_unit_type.0 {
+            h265::NAL_UNIT_TYPE_SPS_NUT => {
+                output.write_all(&[0, 0, 0, 1])?;
+                nalu_header.encode(&mut BitstreamWriter::new(&mut output))?;
+                let mut buf = Vec::new();
+                sps.encode(&mut BitstreamWriter::new(&mut buf))?;
+                let buf = EmulationPrevention::new(buf).collect::<Vec<u8>>();
+                output.write_all(&buf)?;
+            }
+            h265::NAL_UNIT_TYPE_PPS_NUT => {
+                output.write_all(&[0, 0, 0, 1])?;
+                nalu_header.encode(&mut BitstreamWriter::new(&mut output))?;
+                let mut buf = Vec::new();
+                pps.encode(&mut BitstreamWriter::new(&mut buf))?;
+                let buf = EmulationPrevention::new(buf).collect::<Vec<u8>>();
+                output.write_all(&buf)?;
+            }
+            1..=9 | 16..=21 => {
+                // parse the header
+                let bs = Bitstream::new(nalu.iter().copied());
+                let mut nalu = NALUnit::decode(bs)?;
+                let mut header = SliceSegmentHeader::decode(
+                    &mut Bitstream::new(&mut nalu.rbsp_byte),
+                    nalu.nal_unit_header.nal_unit_type.0,
+                    &input_0_sps,
+                    &input_0_pps,
+                )?;
+
+                // write out the new nalus
+
+                let slice_data = nalu.rbsp_byte.into_inner().collect::<Vec<u8>>();
+                output.write_all(&[0, 0, 0, 1])?;
+                nalu_header.encode(&mut BitstreamWriter::new(&mut output))?;
+                let mut buf = Vec::new();
+                header.encode(&mut BitstreamWriter::new(&mut buf), nalu_header.nal_unit_type.0, &sps, &pps)?;
+                let buf = EmulationPrevention::new(buf).collect::<Vec<u8>>();
+                output.write_all(&buf)?;
+                output.write_all(&slice_data)?;
+
+                let mut ctb_x = input_0_sps.PicWidthInCtbsY();
+                for input in &mut inputs[1..] {
+                    header.first_slice_segment_in_pic_flag.0 = 0;
+                    header.slice_segment_address = ctb_x;
+                    ctb_x += input.sps.PicWidthInCtbsY();
+
+                    loop {
+                        let nalu = match input.next_nalu() {
+                            Some(nalu) => nalu?,
+                            None => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "matching slice segment not found").into()),
+                        };
+                        let bs = Bitstream::new(nalu.iter().copied());
+                        let mut nalu = NALUnit::decode(bs)?;
+
+                        match nalu.nal_unit_header.nal_unit_type.0 {
+                            1..=9 | 16..=21 => {
+                                SliceSegmentHeader::decode(
+                                    &mut Bitstream::new(&mut nalu.rbsp_byte),
+                                    nalu.nal_unit_header.nal_unit_type.0,
+                                    &input_0_sps,
+                                    &input_0_pps,
+                                )?;
+                                output.write_all(&[0, 0, 0, 1])?;
+                                nalu_header.encode(&mut BitstreamWriter::new(&mut output))?;
+                                let mut buf = Vec::new();
+                                header.encode(&mut BitstreamWriter::new(&mut buf), nalu_header.nal_unit_type.0, &sps, &pps)?;
+                                let buf = EmulationPrevention::new(buf).collect::<Vec<u8>>();
+                                output.write_all(&buf)?;
+                                let slice_data = nalu.rbsp_byte.into_inner().collect::<Vec<u8>>();
+                                output.write_all(&slice_data)?;
+                                break;
+                            }
+                            _ => {}
+                        }
+                    }
+                }
+            }
+            _ => {
+                output.write_all(&[0, 0, 0, 1])?;
+                output.write_all(nalu)?
+            }
+        }
+    }
+
+    Ok(())
+}
+
+struct Input<Iter, T> {
+    skipped_nalus: VecDeque<T>,
+    nalus: Iter,
+    pps: PictureParameterSet,
+    sps: SequenceParameterSet,
+    current_nalu: Option<T>,
+}
+
+impl<T: AsRef<[u8]>, Iter: Iterator<Item = Result<T, E>>, E: From<io::Error>> Input<Iter, T> {
+    fn new(mut nalus: Iter) -> Result<Self, E> {
+        let mut skipped_nalus = VecDeque::new();
+        let mut sps = None;
+        let mut pps = None;
+        while let Some(nalu) = nalus.next() {
+            let nalu = nalu?;
+            {
+                let bs = Bitstream::new(nalu.as_ref().iter().copied());
+                let mut nalu = NALUnit::decode(bs)?;
+                match nalu.nal_unit_header.nal_unit_type.0 {
+                    h265::NAL_UNIT_TYPE_PPS_NUT => {
+                        let mut rbsp = Bitstream::new(&mut nalu.rbsp_byte);
+                        pps = Some(PictureParameterSet::decode(&mut rbsp)?);
+                    }
+                    h265::NAL_UNIT_TYPE_SPS_NUT => {
+                        let mut rbsp = Bitstream::new(&mut nalu.rbsp_byte);
+                        sps = Some(SequenceParameterSet::decode(&mut rbsp)?);
+                    }
+                    _ => {}
+                }
+            }
+            skipped_nalus.push_back(nalu);
+            if sps.is_some() && pps.is_some() {
+                break;
+            }
+        }
+        match (sps, pps) {
+            (Some(sps), Some(pps)) => Ok(Self {
+                skipped_nalus,
+                nalus,
+                sps,
+                pps,
+                current_nalu: None,
+            }),
+            _ => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "parameter sets not found").into()),
+        }
+    }
+
+    fn next_nalu(&mut self) -> Option<Result<&[u8], E>> {
+        self.current_nalu = Some(if let Some(next) = self.skipped_nalus.pop_front() {
+            next
+        } else {
+            match self.nalus.next()? {
+                Ok(nalu) => nalu,
+                Err(e) => return Some(Err(e)),
+            }
+        });
+        Some(Ok(self.current_nalu.as_ref().expect("we just set this").as_ref()))
+    }
+}

--- a/h265-tile-join/src/lib.rs
+++ b/h265-tile-join/src/lib.rs
@@ -165,7 +165,7 @@ impl<T: AsRef<[u8]>, Iter: Iterator<Item = Result<T, E>>, E: From<io::Error>> In
                 pps,
                 current_nalu: None,
             }),
-            _ => return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "parameter sets not found").into()),
+            _ => Err(io::Error::new(io::ErrorKind::UnexpectedEof, "parameter sets not found").into()),
         }
     }
 

--- a/h265-tile-join/src/main.rs
+++ b/h265-tile-join/src/main.rs
@@ -1,0 +1,38 @@
+use std::fs::File;
+
+mod lib;
+use lib::*;
+
+type BoxError = Box<dyn std::error::Error + Sync + Send>;
+
+fn main() -> Result<(), BoxError> {
+    let matches = clap::App::new("h265-tile-join")
+        .about("joins multiple untiled streams into one tiled stream")
+        .arg(
+            clap::Arg::with_name("input")
+                .long("input")
+                .short("i")
+                .help("the input files. these must be raw h265")
+                .multiple(true)
+                .required(true)
+                .takes_value(true),
+        )
+        .arg(
+            clap::Arg::with_name("output")
+                .long("output")
+                .short("o")
+                .help("the output path")
+                .required(true)
+                .takes_value(true),
+        )
+        .version(env!("CARGO_PKG_VERSION"))
+        .get_matches();
+
+    let inputs = matches.values_of("input").unwrap().map(File::open).collect::<Result<Vec<_>, _>>()?;
+
+    let output = File::create(matches.value_of("output").unwrap())?;
+
+    join(inputs.into_iter().map(h265::read_annex_b), output)?;
+
+    Ok(())
+}

--- a/h265/src/picture_parameter_set.rs
+++ b/h265/src/picture_parameter_set.rs
@@ -2,7 +2,7 @@ use super::{decode, encode, syntax_elements::*, Bitstream, BitstreamWriter, Deco
 use std::io;
 
 // ITU-T H.265, 11/2019 7.3.2.3.1
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct PictureParameterSet {
     pub pps_pic_parameter_set_id: UE,
     pub pps_seq_parameter_set_id: UE,

--- a/h265/src/profile_tier_level.rs
+++ b/h265/src/profile_tier_level.rs
@@ -1,7 +1,7 @@
 use super::{decode, encode, syntax_elements::*, Bitstream, BitstreamWriter, Decode, Encode};
 use std::io;
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ProfileTierLevel {
     // if( profilePresentFlag ) {
     pub general_profile_space: U2,

--- a/h265/src/sequence_parameter_set.rs
+++ b/h265/src/sequence_parameter_set.rs
@@ -1,7 +1,7 @@
 use super::{decode, encode, syntax_elements::*, Bitstream, BitstreamWriter, Decode, Encode, ProfileTierLevel};
 use std::io;
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SequenceParameterSetSubLayerOrderingInfo {
     pub sps_max_dec_pic_buffering_minus1: UE,
     pub sps_max_num_reorder_pics: UE,
@@ -29,7 +29,7 @@ impl Encode for SequenceParameterSetSubLayerOrderingInfo {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct ShortTermRefPicSet {
     // if( stRpsIdx != 0 )
     pub inter_ref_pic_set_prediction_flag: U1,
@@ -114,7 +114,7 @@ impl ShortTermRefPicSet {
 }
 
 // ITU-T H.265, 11/2019 7.3.2.1.1
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct SequenceParameterSet {
     pub sps_video_parameter_set_id: U4,
     pub sps_max_sub_layers_minus1: U3,
@@ -484,7 +484,7 @@ impl Encode for SequenceParameterSet {
     }
 }
 
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct VUIParameters {
     pub aspect_ratio_info_present_flag: U1,
 

--- a/h265/src/slice_segment_header.rs
+++ b/h265/src/slice_segment_header.rs
@@ -24,7 +24,7 @@ pub struct RefPicListsModification {
 }
 
 fn ceil_log2(n: u64) -> u32 {
-    (n - 1).next_power_of_two().trailing_zeros()
+    n.next_power_of_two().trailing_zeros()
 }
 
 impl RefPicListsModification {
@@ -615,6 +615,14 @@ impl SliceSegmentHeader {
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn test_ceil_log2() {
+        assert_eq!(ceil_log2(1), 0);
+        assert_eq!(ceil_log2(2), 1);
+        assert_eq!(ceil_log2(3), 2);
+        assert_eq!(ceil_log2(4), 2);
+    }
 
     #[test]
     fn test_slice_segment_header() {


### PR DESCRIPTION
* Adds h265-tile-join, a demo program / library for joining untiled video into a single tiled video. See the conversation in Slack.
* Fixes `ceil_log2`, which I broke because `next_power_of_two` doesn't return the _next_ power of two for powers of two. Stupid name. :P Now it's fixed again and has more tests.
* Makes several things `Clone`.