### PR TITLE
add av-foundation crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,8 @@ members = [
     "h265-tile-mux",
     "h265-tile-join",
     "hmp",
+    "macos/foundation",
+    "macos/av-foundation",
     "macos/core-foundation",
     "macos/core-media",
     "macos/core-video",

--- a/macos/av-foundation/Cargo.toml
+++ b/macos/av-foundation/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "av-foundation"
+version = "0.1.0"
+edition = "2018"
+build = "build.rs"
+
+[dependencies]
+foundation = { path = "../foundation" }
+core-foundation = { path = "../core-foundation" }
+core-media = { path = "../core-media" }
+
+[build-dependencies]
+cc = "1.0"

--- a/macos/av-foundation/build.rs
+++ b/macos/av-foundation/build.rs
@@ -1,0 +1,21 @@
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-lib=framework=Foundation");
+        println!("cargo:rustc-link-lib=framework=AVFoundation");
+
+        cc::Build::new()
+            .files(
+                [
+                    "src/lib.mm",
+                    "src/av_capture_video_data_output.mm",
+                    "src/av_capture_device.mm",
+                    "src/av_media_type.mm",
+                    "src/av_capture_session.mm",
+                ]
+                .iter(),
+            )
+            .flag("-fobjc-arc")
+            .compile("av-foundation");
+    }
+}

--- a/macos/av-foundation/build.rs
+++ b/macos/av-foundation/build.rs
@@ -3,6 +3,7 @@ fn main() {
     {
         println!("cargo:rustc-link-lib=framework=Foundation");
         println!("cargo:rustc-link-lib=framework=AVFoundation");
+        println!("cargo:rustc-link-lib=c++");
 
         cc::Build::new()
             .files(

--- a/macos/av-foundation/src/av_capture_device.mm
+++ b/macos/av-foundation/src/av_capture_device.mm
@@ -1,0 +1,95 @@
+#import "av_media_type.h"
+
+#if !__has_feature(objc_arc)
+#error "ARC is off"
+#endif
+
+extern "C" const void* avrs_default_av_capture_device(int mediaType) {
+    @autoreleasepool {
+        AVCaptureDevice* device = [AVCaptureDevice defaultDeviceWithMediaType:avrs_av_media_type_from_int(mediaType)];
+        if (!device) {
+            return nil;
+        }
+        return (__bridge_retained void*)device;
+    }
+}
+
+extern "C" bool avrs_avf_request_av_capture_device_access(int mediaTypeIn) {
+    AVMediaType mediaType = avrs_av_media_type_from_int(mediaTypeIn);
+
+    AVAuthorizationStatus status = [AVCaptureDevice authorizationStatusForMediaType:mediaType];
+    if (status == AVAuthorizationStatusAuthorized) {
+        return true;
+    }
+
+    dispatch_group_t group = dispatch_group_create();
+    __block bool accessGranted = false;
+    dispatch_group_enter(group);
+    [AVCaptureDevice requestAccessForMediaType:mediaType completionHandler:^(BOOL granted) {
+        accessGranted = granted;
+        dispatch_group_leave(group);
+    }];
+    dispatch_group_wait(group, dispatch_time(DISPATCH_TIME_NOW, (int64_t)(60.0 * NSEC_PER_SEC)));
+
+    return accessGranted;
+}
+
+extern "C" bool avrs_avf_av_capture_device_configure(const void* deviceIn, Float64 fps) {
+    @autoreleasepool {
+        AVCaptureDevice* device = ((__bridge AVCaptureDevice*)deviceIn);
+        AVCaptureDeviceFormat* best = nil;
+        int32_t bestHeight = 0;
+        AVFrameRateRange* bestFrameRateRange = nil;
+        for (AVCaptureDeviceFormat* format in device.formats) {
+            CMVideoDimensions dims = CMVideoFormatDescriptionGetDimensions(format.formatDescription);
+            if (dims.height < bestHeight) {
+                continue;
+            }
+
+            AVFrameRateRange* frameRateRange = nil;
+            if (fps) {
+                for (AVFrameRateRange* r in format.videoSupportedFrameRateRanges) {
+                    if (r.minFrameRate - 0.0001 <= fps && r.maxFrameRate + 0.0001 >= fps) {
+                        frameRateRange = r;
+                    }
+                }
+            }
+
+            if (!fps || frameRateRange) {
+                best = format;
+                bestHeight = dims.height;
+                bestFrameRateRange = frameRateRange;
+            }
+        }
+
+        if (!best || ![device lockForConfiguration:nil]) {
+            return false;
+        }
+        @try {
+            device.activeFormat = best;
+            if (bestFrameRateRange) {
+                device.activeVideoMinFrameDuration = bestFrameRateRange.minFrameDuration;
+                device.activeVideoMaxFrameDuration = bestFrameRateRange.minFrameDuration;
+            }
+        } @catch(id anException) {
+            NSLog(@"%@", anException);
+            [device unlockForConfiguration];
+            return false;
+        }
+        [device unlockForConfiguration];
+        return true;
+    }
+}
+
+extern "C" const void* avrs_avf_av_capture_device_input_from_device(const void* deviceIn, const void** errorOut) {
+    @autoreleasepool {
+        AVCaptureDevice* device = ((__bridge AVCaptureDevice*)deviceIn);
+        NSError* error = nil;
+        AVCaptureDeviceInput* deviceInput = [AVCaptureDeviceInput deviceInputWithDevice:device error:&error];
+        if (error) {
+            *errorOut = (__bridge_retained void*)error;
+            return nil;
+        }
+        return (__bridge_retained void*)deviceInput;
+    }
+}

--- a/macos/av-foundation/src/av_capture_device.rs
+++ b/macos/av-foundation/src/av_capture_device.rs
@@ -1,0 +1,75 @@
+use super::{AVCaptureInput, AVMediaType};
+use foundation::NSError;
+use std::ffi::c_void;
+
+pub mod sys {
+    use std::{ffi::c_void, os::raw::c_int};
+
+    extern "C" {
+        pub fn avrs_default_av_capture_device(media_type: c_int) -> *const c_void;
+        pub fn avrs_avf_request_av_capture_device_access(media_type: c_int) -> bool;
+        pub fn avrs_avf_av_capture_device_input_from_device(device: *const c_void, err: *mut *const c_void) -> *const c_void;
+        pub fn avrs_avf_av_capture_device_configure(device: *const c_void, fps: f64) -> bool;
+    }
+}
+
+pub struct AVCaptureDevice(*const c_void);
+
+pub struct AVCaptureDeviceConfig {
+    pub fps: Option<f64>,
+}
+
+impl AVCaptureDevice {
+    pub fn default_with_media_type(media_type: AVMediaType) -> Option<Self> {
+        let raw = unsafe { sys::avrs_default_av_capture_device(media_type.as_sys()) };
+        if raw.is_null() {
+            None
+        } else {
+            Some(Self(raw))
+        }
+    }
+
+    /// Requests access for the given media type if needed and blocks until it is granted or
+    /// denied. Returns true if access is granted and false otherwise.
+    pub fn request_access(media_type: AVMediaType) -> bool {
+        unsafe { sys::avrs_avf_request_av_capture_device_access(media_type.as_sys()) }
+    }
+
+    pub fn configure(&self, config: AVCaptureDeviceConfig) -> bool {
+        unsafe { sys::avrs_avf_av_capture_device_configure(self.0, config.fps.unwrap_or(0.0)) }
+    }
+}
+
+impl Drop for AVCaptureDevice {
+    fn drop(&mut self) {
+        unsafe { super::sys::avrs_avf_release_object(self.0) }
+    }
+}
+
+pub struct AVCaptureDeviceInput(*const c_void);
+
+impl AVCaptureDeviceInput {
+    pub fn new(device: &AVCaptureDevice) -> Result<Self, NSError> {
+        unsafe {
+            let mut err: *const c_void = std::ptr::null();
+            let input = sys::avrs_avf_av_capture_device_input_from_device(device.0, &mut err as _);
+            if err.is_null() {
+                Ok(Self(input))
+            } else {
+                Err(NSError::from_raw(err))
+            }
+        }
+    }
+}
+
+impl AVCaptureInput for &AVCaptureDeviceInput {
+    fn raw(&self) -> *const c_void {
+        self.0
+    }
+}
+
+impl Drop for AVCaptureDeviceInput {
+    fn drop(&mut self) {
+        unsafe { super::sys::avrs_avf_release_object(self.0) }
+    }
+}

--- a/macos/av-foundation/src/av_capture_input.rs
+++ b/macos/av-foundation/src/av_capture_input.rs
@@ -1,0 +1,5 @@
+use std::ffi::c_void;
+
+pub trait AVCaptureInput {
+    fn raw(&self) -> *const c_void;
+}

--- a/macos/av-foundation/src/av_capture_output.rs
+++ b/macos/av-foundation/src/av_capture_output.rs
@@ -1,0 +1,5 @@
+use std::ffi::c_void;
+
+pub trait AVCaptureOutput {
+    fn raw(&self) -> *const c_void;
+}

--- a/macos/av-foundation/src/av_capture_session.mm
+++ b/macos/av-foundation/src/av_capture_session.mm
@@ -1,0 +1,73 @@
+#import <AVFoundation/AVFoundation.h>
+
+#if !__has_feature(objc_arc)
+#error "ARC is off"
+#endif
+
+extern "C" const void* avrs_new_av_capture_session() {
+    @autoreleasepool {
+        AVCaptureSession* sess = [AVCaptureSession new];
+        return (__bridge_retained void*)sess;
+    }
+}
+
+extern "C" BOOL avrs_av_capture_session_can_add_input(const void* sessIn, const void* inputIn) {
+    @autoreleasepool {
+        AVCaptureSession* sess = ((__bridge AVCaptureSession*)sessIn);
+        sess.sessionPreset = AVCaptureSessionPresetMedium;
+        AVCaptureDeviceInput* input = ((__bridge AVCaptureDeviceInput*)inputIn);
+        return [sess canAddInput:input];
+    }
+}
+
+extern "C" void avrs_av_capture_session_add_input(const void* sessIn, const void* inputIn) {
+    @autoreleasepool {
+        AVCaptureSession* sess = ((__bridge AVCaptureSession*)sessIn);
+        AVCaptureInput* input = ((__bridge AVCaptureInput*)inputIn);
+        [sess addInput:input];
+    }
+}
+
+extern "C" BOOL avrs_av_capture_session_can_add_output(const void* sessIn, const void* outputIn) {
+    @autoreleasepool {
+        AVCaptureSession* sess = ((__bridge AVCaptureSession*)sessIn);
+        AVCaptureOutput* output = ((__bridge AVCaptureOutput*)outputIn);
+        return [sess canAddOutput:output];
+    }
+}
+
+extern "C" void avrs_av_capture_session_add_output(const void* sessIn, const void* outputIn) {
+    @autoreleasepool {
+        AVCaptureSession* sess = ((__bridge AVCaptureSession*)sessIn);
+        AVCaptureOutput* output = ((__bridge AVCaptureOutput*)outputIn);
+        [sess addOutput:output];
+    }
+}
+
+extern "C" void avrs_av_capture_session_start_running(const void* sessIn) {
+    @autoreleasepool {
+        AVCaptureSession* sess = ((__bridge AVCaptureSession*)sessIn);
+        [sess startRunning];
+    }
+}
+
+extern "C" void avrs_av_capture_session_stop_running(const void* sessIn) {
+    @autoreleasepool {
+        AVCaptureSession* sess = ((__bridge AVCaptureSession*)sessIn);
+        [sess stopRunning];
+    }
+}
+
+extern "C" void avrs_av_capture_session_begin_configuration(const void* sessIn) {
+    @autoreleasepool {
+        AVCaptureSession* sess = ((__bridge AVCaptureSession*)sessIn);
+        [sess beginConfiguration];
+    }
+}
+
+extern "C" void avrs_av_capture_session_commit_configuration(const void* sessIn) {
+    @autoreleasepool {
+        AVCaptureSession* sess = ((__bridge AVCaptureSession*)sessIn);
+        [sess commitConfiguration];
+    }
+}

--- a/macos/av-foundation/src/av_capture_session.rs
+++ b/macos/av-foundation/src/av_capture_session.rs
@@ -19,6 +19,12 @@ pub mod sys {
 
 pub struct AVCaptureSession(*const c_void);
 
+impl Default for AVCaptureSession {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AVCaptureSession {
     pub fn new() -> Self {
         Self(unsafe { sys::avrs_new_av_capture_session() })

--- a/macos/av-foundation/src/av_capture_session.rs
+++ b/macos/av-foundation/src/av_capture_session.rs
@@ -1,0 +1,76 @@
+use super::{AVCaptureInput, AVCaptureOutput};
+use std::ffi::c_void;
+
+pub mod sys {
+    use std::ffi::c_void;
+
+    extern "C" {
+        pub fn avrs_new_av_capture_session() -> *const c_void;
+        pub fn avrs_av_capture_session_can_add_input(sess: *const c_void, input: *const c_void) -> bool;
+        pub fn avrs_av_capture_session_add_input(sess: *const c_void, input: *const c_void);
+        pub fn avrs_av_capture_session_can_add_output(sess: *const c_void, output: *const c_void) -> bool;
+        pub fn avrs_av_capture_session_add_output(sess: *const c_void, output: *const c_void);
+        pub fn avrs_av_capture_session_start_running(sess: *const c_void);
+        pub fn avrs_av_capture_session_stop_running(sess: *const c_void);
+        pub fn avrs_av_capture_session_begin_configuration(sess: *const c_void);
+        pub fn avrs_av_capture_session_commit_configuration(sess: *const c_void);
+    }
+}
+
+pub struct AVCaptureSession(*const c_void);
+
+impl AVCaptureSession {
+    pub fn new() -> Self {
+        Self(unsafe { sys::avrs_new_av_capture_session() })
+    }
+
+    pub fn begin_configuration(&self) {
+        unsafe { sys::avrs_av_capture_session_begin_configuration(self.0) }
+    }
+
+    pub fn commit_configuration(&self) {
+        unsafe { sys::avrs_av_capture_session_commit_configuration(self.0) }
+    }
+
+    pub fn can_add_input<I: AVCaptureInput>(&self, input: I) -> bool {
+        unsafe { sys::avrs_av_capture_session_can_add_input(self.0, input.raw()) }
+    }
+
+    pub fn add_input<I: AVCaptureInput>(&self, input: I) {
+        unsafe { sys::avrs_av_capture_session_add_input(self.0, input.raw()) }
+    }
+
+    pub fn can_add_output<O: AVCaptureOutput>(&self, output: O) -> bool {
+        unsafe { sys::avrs_av_capture_session_can_add_output(self.0, output.raw()) }
+    }
+
+    pub fn add_output<O: AVCaptureOutput>(&self, output: O) {
+        unsafe { sys::avrs_av_capture_session_add_output(self.0, output.raw()) }
+    }
+
+    pub fn start_running(&self) {
+        unsafe { sys::avrs_av_capture_session_start_running(self.0) }
+    }
+
+    pub fn stop_running(&self) {
+        unsafe { sys::avrs_av_capture_session_stop_running(self.0) }
+    }
+}
+
+unsafe impl Send for AVCaptureSession {}
+
+impl Drop for AVCaptureSession {
+    fn drop(&mut self) {
+        unsafe { super::sys::avrs_avf_release_object(self.0) }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_av_capture_session() {
+        let _ = AVCaptureSession::new();
+    }
+}

--- a/macos/av-foundation/src/av_capture_video_data_output.mm
+++ b/macos/av-foundation/src/av_capture_video_data_output.mm
@@ -1,0 +1,51 @@
+#import <AVFoundation/AVFoundation.h>
+
+#if !__has_feature(objc_arc)
+#error "ARC is off"
+#endif
+
+extern "C" const void* avrs_new_av_capture_video_data_output() {
+    @autoreleasepool {
+        AVCaptureVideoDataOutput* output = [AVCaptureVideoDataOutput new];
+        return (__bridge_retained void*)output;
+    }
+}
+
+@interface RustAVCaptureVideoDataOutputSampleBufferDelegate: NSObject<AVCaptureVideoDataOutputSampleBufferDelegate>
+    @property const void* impl;
+@end
+
+extern "C" void avrs_av_capture_video_data_output_sample_buffer_delegate_did_output(const void*, CMSampleBufferRef);
+
+@implementation RustAVCaptureVideoDataOutputSampleBufferDelegate
+- (void)captureOutput:(AVCaptureOutput *)output didOutputSampleBuffer:(CMSampleBufferRef)sampleBuffer fromConnection:(AVCaptureConnection *)connection {
+    avrs_av_capture_video_data_output_sample_buffer_delegate_did_output(self.impl, sampleBuffer);
+}
+@end
+
+extern "C" const void* avrs_new_av_capture_video_data_output_sample_buffer_delegate(const void* delegateIn) {
+    @autoreleasepool {
+        RustAVCaptureVideoDataOutputSampleBufferDelegate* delegate = [RustAVCaptureVideoDataOutputSampleBufferDelegate new];
+        delegate.impl = delegateIn;
+        return (__bridge_retained void*)delegate;
+    }
+}
+
+extern "C" void avrs_new_av_capture_video_data_output_set_sample_buffer_delegate(const void* outputIn, const void* delegateIn) {
+    @autoreleasepool {
+        AVCaptureVideoDataOutput* output = ((__bridge AVCaptureVideoDataOutput*)outputIn);
+        RustAVCaptureVideoDataOutputSampleBufferDelegate* delegate = ((__bridge RustAVCaptureVideoDataOutputSampleBufferDelegate*)delegateIn);
+        [output setSampleBufferDelegate:delegate queue:dispatch_queue_create("avrs.video-data-output", NULL)];
+    }
+}
+
+extern "C" void avrs_new_av_capture_video_data_output_set_video_settings(const void* outputIn, uint32_t pixelFormatType) {
+    @autoreleasepool {
+        AVCaptureVideoDataOutput* output = ((__bridge AVCaptureVideoDataOutput*)outputIn);
+        if (pixelFormatType) {
+            output.videoSettings = @{(NSString*)kCVPixelBufferPixelFormatTypeKey: [NSNumber numberWithUnsignedInt:pixelFormatType]};
+        } else {
+            output.videoSettings = @{};
+        }
+    }
+}

--- a/macos/av-foundation/src/av_capture_video_data_output.rs
+++ b/macos/av-foundation/src/av_capture_video_data_output.rs
@@ -60,6 +60,12 @@ pub struct AVCaptureVideoDataOutputVideoSettings {
     pub pixel_format_type: Option<u32>,
 }
 
+impl Default for AVCaptureVideoDataOutput {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AVCaptureVideoDataOutput {
     pub fn new() -> Self {
         Self(unsafe { sys::avrs_new_av_capture_video_data_output() })

--- a/macos/av-foundation/src/av_capture_video_data_output.rs
+++ b/macos/av-foundation/src/av_capture_video_data_output.rs
@@ -1,0 +1,91 @@
+use super::AVCaptureOutput;
+use core_foundation::CFType;
+use core_media::{sys::CMSampleBufferRef, SampleBuffer};
+use std::ffi::c_void;
+
+pub mod sys {
+    use std::ffi::c_void;
+
+    extern "C" {
+        pub fn avrs_new_av_capture_video_data_output() -> *const c_void;
+        pub fn avrs_new_av_capture_video_data_output_set_sample_buffer_delegate(output: *const c_void, delegate: *const c_void);
+        pub fn avrs_new_av_capture_video_data_output_sample_buffer_delegate(implementation: *const c_void) -> *const c_void;
+        pub fn avrs_new_av_capture_video_data_output_set_video_settings(output: *const c_void, pixel_format: u32);
+    }
+}
+
+pub struct AVCaptureVideoDataOutput(*const c_void);
+
+pub trait AVCaptureVideoDataOutputSampleBufferDelegateProtocol {
+    fn did_output_sample_buffer(&self, _buffer: SampleBuffer) {}
+}
+
+pub struct AVCaptureVideoDataOutputSampleBufferDelegate {
+    raw: *const c_void,
+    _native: Box<Box<dyn AVCaptureVideoDataOutputSampleBufferDelegateProtocol + Send>>,
+}
+
+unsafe impl Send for AVCaptureVideoDataOutputSampleBufferDelegate {}
+
+impl AVCaptureVideoDataOutputSampleBufferDelegate {
+    pub fn new<D: 'static + AVCaptureVideoDataOutputSampleBufferDelegateProtocol + Send>(delegate: D) -> AVCaptureVideoDataOutputSampleBufferDelegate {
+        let delegate: Box<Box<dyn AVCaptureVideoDataOutputSampleBufferDelegateProtocol + Send>> = Box::new(Box::new(delegate));
+        Self {
+            raw: unsafe {
+                sys::avrs_new_av_capture_video_data_output_sample_buffer_delegate(
+                    &*delegate as *const Box<dyn AVCaptureVideoDataOutputSampleBufferDelegateProtocol + Send> as _,
+                )
+            },
+            _native: delegate,
+        }
+    }
+}
+
+impl Drop for AVCaptureVideoDataOutputSampleBufferDelegate {
+    fn drop(&mut self) {
+        unsafe { super::sys::avrs_avf_release_object(self.raw) }
+    }
+}
+
+#[no_mangle]
+unsafe extern "C" fn avrs_av_capture_video_data_output_sample_buffer_delegate_did_output(
+    implementation: *const Box<dyn AVCaptureVideoDataOutputSampleBufferDelegateProtocol>,
+    buffer: CMSampleBufferRef,
+) {
+    let implementation = &*implementation;
+    implementation.did_output_sample_buffer(SampleBuffer::with_cf_type_ref(buffer as _));
+}
+
+pub struct AVCaptureVideoDataOutputVideoSettings {
+    pub pixel_format_type: Option<u32>,
+}
+
+impl AVCaptureVideoDataOutput {
+    pub fn new() -> Self {
+        Self(unsafe { sys::avrs_new_av_capture_video_data_output() })
+    }
+
+    /// Sets the sample buffer delegate. The output only retains a weak reference to this delegate,
+    /// so you must keep it alive for as long as you need it to function.
+    pub fn set_sample_buffer_delegate(&self, delegate: &AVCaptureVideoDataOutputSampleBufferDelegate) {
+        unsafe {
+            sys::avrs_new_av_capture_video_data_output_set_sample_buffer_delegate(self.0, delegate.raw);
+        }
+    }
+
+    pub fn set_video_settings(&self, settings: &AVCaptureVideoDataOutputVideoSettings) {
+        unsafe { sys::avrs_new_av_capture_video_data_output_set_video_settings(self.0, settings.pixel_format_type.unwrap_or(0)) }
+    }
+}
+
+impl AVCaptureOutput for &AVCaptureVideoDataOutput {
+    fn raw(&self) -> *const c_void {
+        self.0
+    }
+}
+
+impl Drop for AVCaptureVideoDataOutput {
+    fn drop(&mut self) {
+        unsafe { super::sys::avrs_avf_release_object(self.0) }
+    }
+}

--- a/macos/av-foundation/src/av_media_type.h
+++ b/macos/av-foundation/src/av_media_type.h
@@ -1,0 +1,3 @@
+#import <AVFoundation/AVFoundation.h>
+
+AVMediaType avrs_av_media_type_from_int(int id);

--- a/macos/av-foundation/src/av_media_type.mm
+++ b/macos/av-foundation/src/av_media_type.mm
@@ -1,0 +1,13 @@
+#import <AVFoundation/AVFoundation.h>
+
+#if !__has_feature(objc_arc)
+#error "ARC is off"
+#endif
+
+AVMediaType avrs_av_media_type_from_int(int id) {
+    if (id == 0) {
+        return AVMediaTypeAudio;
+    } else {
+        return AVMediaTypeVideo;
+    }
+}

--- a/macos/av-foundation/src/av_media_type.rs
+++ b/macos/av-foundation/src/av_media_type.rs
@@ -1,0 +1,15 @@
+use std::os::raw::c_int;
+
+pub enum AVMediaType {
+    Audio,
+    Video,
+}
+
+impl AVMediaType {
+    pub(crate) fn as_sys(&self) -> c_int {
+        match self {
+            Self::Audio => 0,
+            Self::Video => 1,
+        }
+    }
+}

--- a/macos/av-foundation/src/lib.mm
+++ b/macos/av-foundation/src/lib.mm
@@ -1,0 +1,12 @@
+#import <AVFoundation/AVFoundation.h>
+
+#if !__has_feature(objc_arc)
+#error "ARC is off"
+#endif
+
+extern "C" void avrs_avf_release_object(const void* obj) {
+    @autoreleasepool {
+        id m = (__bridge_transfer id)obj;
+        m = nil;
+    }
+}

--- a/macos/av-foundation/src/lib.rs
+++ b/macos/av-foundation/src/lib.rs
@@ -1,0 +1,27 @@
+#![cfg(target_os = "macos")]
+
+pub mod sys {
+    use std::ffi::c_void;
+
+    extern "C" {
+        pub fn avrs_avf_release_object(obj: *const c_void);
+    }
+}
+
+pub mod av_capture_device;
+pub use av_capture_device::*;
+
+pub mod av_capture_input;
+pub use av_capture_input::*;
+
+pub mod av_capture_output;
+pub use av_capture_output::*;
+
+pub mod av_capture_video_data_output;
+pub use av_capture_video_data_output::*;
+
+pub mod av_capture_session;
+pub use av_capture_session::*;
+
+pub mod av_media_type;
+pub use av_media_type::*;

--- a/macos/core-media/Cargo.toml
+++ b/macos/core-media/Cargo.toml
@@ -10,3 +10,4 @@ bindgen = "0.*"
 
 [dependencies]
 core-foundation = { path = "../core-foundation" }
+core-video = { path = "../core-video" }

--- a/macos/core-media/src/block_buffer.rs
+++ b/macos/core-media/src/block_buffer.rs
@@ -5,9 +5,10 @@ pub struct BlockBuffer(sys::CMBlockBufferRef);
 core_foundation::trait_impls!(BlockBuffer);
 
 impl BlockBuffer {
-    /// Creates a new block buffer that references the given memory block, without copying it. This
-    /// is unsafe because the caller must ensure that the given block out-lives the BlockBuffer.
-    #[allow(clippy::missing_safety_doc)]
+    /// Creates a new block buffer that references the given memory block, without copying it.
+    ///
+    /// # Safety
+    /// This is unsafe because the caller must ensure that the given block out-lives the BlockBuffer.
     pub unsafe fn with_memory_block(block: &[u8]) -> Result<Self, OSStatus> {
         let mut ret = std::ptr::null_mut();
         result(

--- a/macos/core-media/src/sample_buffer.rs
+++ b/macos/core-media/src/sample_buffer.rs
@@ -40,4 +40,15 @@ impl SampleBuffer {
         )?;
         Ok(Self(ret))
     }
+
+    pub fn image_buffer(&self) -> Option<core_video::ImageBuffer> {
+        unsafe {
+            let buf = sys::CMSampleBufferGetImageBuffer(self.0);
+            if buf.is_null() {
+                None
+            } else {
+                Some(core_video::ImageBuffer::with_cf_type_ref(buf as _))
+            }
+        }
+    }
 }

--- a/macos/core-video/build.rs
+++ b/macos/core-video/build.rs
@@ -12,6 +12,8 @@ fn main() {
             .clang_arg(format!("-isysroot{}", sdk_root))
             .header("src/lib.hpp")
             .whitelist_function("CVImageBuffer.+")
+            .whitelist_function("CVPixelBuffer.+")
+            .whitelist_var("kCVPixelBufferLock_ReadOnly")
             .generate()
             .expect("unable to generate bindings");
 

--- a/macos/core-video/src/image_buffer.rs
+++ b/macos/core-video/src/image_buffer.rs
@@ -1,4 +1,11 @@
-use super::sys;
+use super::{sys, PixelBuffer};
+use core_foundation::CFType;
 
 pub struct ImageBuffer(sys::CVImageBufferRef);
 core_foundation::trait_impls!(ImageBuffer);
+
+impl ImageBuffer {
+    pub fn pixel_buffer(&self) -> PixelBuffer {
+        unsafe { PixelBuffer::with_cf_type_ref(self.0 as _) }
+    }
+}

--- a/macos/core-video/src/lib.rs
+++ b/macos/core-video/src/lib.rs
@@ -1,9 +1,18 @@
 #![cfg(target_os = "macos")]
 
 pub mod sys {
-    #![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, clippy::unreadable_literal, clippy::cognitive_complexity)]
+    #![allow(
+        non_snake_case,
+        non_upper_case_globals,
+        non_camel_case_types,
+        clippy::unreadable_literal,
+        clippy::cognitive_complexity
+    )]
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
 pub mod image_buffer;
 pub use image_buffer::*;
+
+pub mod pixel_buffer;
+pub use pixel_buffer::*;

--- a/macos/core-video/src/pixel_buffer.rs
+++ b/macos/core-video/src/pixel_buffer.rs
@@ -1,0 +1,39 @@
+use super::sys;
+use std::ffi::c_void;
+
+pub struct PixelBuffer(sys::CVPixelBufferRef);
+core_foundation::trait_impls!(PixelBuffer);
+
+impl PixelBuffer {
+    pub fn pixel_format_type(&self) -> u32 {
+        unsafe { sys::CVPixelBufferGetPixelFormatType(self.0) }
+    }
+
+    pub fn width(&self) -> u64 {
+        unsafe { sys::CVPixelBufferGetWidth(self.0) }
+    }
+
+    pub fn height(&self) -> u64 {
+        unsafe { sys::CVPixelBufferGetHeight(self.0) }
+    }
+
+    pub fn base_address_of_plane(&self, i: usize) -> *const c_void {
+        unsafe { sys::CVPixelBufferGetBaseAddressOfPlane(self.0, i as _) }
+    }
+
+    pub fn base_address(&self) -> *const c_void {
+        unsafe { sys::CVPixelBufferGetBaseAddress(self.0) }
+    }
+
+    pub fn lock_base_address(&self) {
+        unsafe { sys::CVPixelBufferLockBaseAddress(self.0, sys::kCVPixelBufferLock_ReadOnly as _) };
+    }
+
+    pub fn unlock_base_address(&self) {
+        unsafe { sys::CVPixelBufferUnlockBaseAddress(self.0, sys::kCVPixelBufferLock_ReadOnly as _) };
+    }
+
+    pub fn data_size(&self) -> usize {
+        unsafe { sys::CVPixelBufferGetDataSize(self.0) as usize }
+    }
+}

--- a/macos/foundation/Cargo.toml
+++ b/macos/foundation/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "foundation"
+version = "0.1.0"
+edition = "2018"
+build = "build.rs"
+
+[build-dependencies]
+cc = "1.0"

--- a/macos/foundation/build.rs
+++ b/macos/foundation/build.rs
@@ -1,0 +1,11 @@
+fn main() {
+    #[cfg(target_os = "macos")]
+    {
+        println!("cargo:rustc-link-lib=framework=Foundation");
+
+        cc::Build::new()
+            .files(["src/lib.mm", "src/nserror.mm", "src/nsstring.mm"].iter())
+            .flag("-fobjc-arc")
+            .compile("foundation");
+    }
+}

--- a/macos/foundation/src/lib.mm
+++ b/macos/foundation/src/lib.mm
@@ -1,0 +1,12 @@
+#import <AVFoundation/AVFoundation.h>
+
+#if !__has_feature(objc_arc)
+#error "ARC is off"
+#endif
+
+extern "C" void avrs_foundation_release_object(const void* obj) {
+    @autoreleasepool {
+        id m = (__bridge_transfer id)obj;
+        m = nil;
+    }
+}

--- a/macos/foundation/src/lib.rs
+++ b/macos/foundation/src/lib.rs
@@ -1,0 +1,15 @@
+#![cfg(target_os = "macos")]
+
+pub mod sys {
+    use std::ffi::c_void;
+
+    extern "C" {
+        pub fn avrs_foundation_release_object(obj: *const c_void);
+    }
+}
+
+pub mod nserror;
+pub use nserror::*;
+
+pub mod nsstring;
+pub use nsstring::*;

--- a/macos/foundation/src/nserror.mm
+++ b/macos/foundation/src/nserror.mm
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+extern "C" const void* avrs_nserror_localized_description(const void* errIn) {
+    @autoreleasepool {
+        NSError* err = ((__bridge NSError*)errIn);
+        NSString* desc = [err localizedDescription];
+        return (__bridge_retained void*)desc;
+    }
+}

--- a/macos/foundation/src/nserror.rs
+++ b/macos/foundation/src/nserror.rs
@@ -1,0 +1,46 @@
+use super::NSString;
+use std::{error::Error, ffi::c_void, fmt};
+
+mod sys {
+    use std::ffi::c_void;
+
+    extern "C" {
+        pub fn avrs_nserror_localized_description(err: *const c_void) -> *const c_void;
+    }
+}
+
+pub struct NSError(*const c_void);
+
+unsafe impl Send for NSError {}
+unsafe impl Sync for NSError {}
+
+impl fmt::Debug for NSError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.localized_description())
+    }
+}
+
+impl fmt::Display for NSError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.localized_description())
+    }
+}
+
+impl Error for NSError {}
+
+impl NSError {
+    pub unsafe fn from_raw(ptr: *const c_void) -> Self {
+        Self(ptr)
+    }
+
+    pub fn localized_description(&self) -> String {
+        let s = unsafe { NSString::from_raw(sys::avrs_nserror_localized_description(self.0)) };
+        s.as_str().to_string()
+    }
+}
+
+impl Drop for NSError {
+    fn drop(&mut self) {
+        unsafe { super::sys::avrs_foundation_release_object(self.0) }
+    }
+}

--- a/macos/foundation/src/nserror.rs
+++ b/macos/foundation/src/nserror.rs
@@ -29,6 +29,8 @@ impl fmt::Display for NSError {
 impl Error for NSError {}
 
 impl NSError {
+    /// # Safety
+    /// The caller must ensure that the given pointer is a valid NSError pointer.
     pub unsafe fn from_raw(ptr: *const c_void) -> Self {
         Self(ptr)
     }

--- a/macos/foundation/src/nsstring.mm
+++ b/macos/foundation/src/nsstring.mm
@@ -1,0 +1,8 @@
+#import <Foundation/Foundation.h>
+
+extern "C" const char* avrs_nsstring_utf8_string(const void* strIn) {
+    @autoreleasepool {
+        NSString* str = ((__bridge NSString*)strIn);
+        return [str UTF8String];
+    }
+}

--- a/macos/foundation/src/nsstring.rs
+++ b/macos/foundation/src/nsstring.rs
@@ -12,7 +12,7 @@ pub struct NSString(*const c_void);
 
 impl NSString {
     /// # Safety
-    /// The caller must ensure that the given pointer is a valid NSError pointer.
+    /// The caller must ensure that the given pointer is a valid NSString pointer.
     pub unsafe fn from_raw(ptr: *const c_void) -> Self {
         Self(ptr)
     }

--- a/macos/foundation/src/nsstring.rs
+++ b/macos/foundation/src/nsstring.rs
@@ -11,6 +11,8 @@ mod sys {
 pub struct NSString(*const c_void);
 
 impl NSString {
+    /// # Safety
+    /// The caller must ensure that the given pointer is a valid NSError pointer.
     pub unsafe fn from_raw(ptr: *const c_void) -> Self {
         Self(ptr)
     }

--- a/macos/foundation/src/nsstring.rs
+++ b/macos/foundation/src/nsstring.rs
@@ -1,0 +1,28 @@
+use std::ffi::{c_void, CStr};
+
+mod sys {
+    use std::ffi::c_void;
+
+    extern "C" {
+        pub fn avrs_nsstring_utf8_string(str: *const c_void) -> *const i8;
+    }
+}
+
+pub struct NSString(*const c_void);
+
+impl NSString {
+    pub unsafe fn from_raw(ptr: *const c_void) -> Self {
+        Self(ptr)
+    }
+
+    pub fn as_str(&self) -> &str {
+        let s = unsafe { CStr::from_ptr(sys::avrs_nsstring_utf8_string(self.0)) };
+        s.to_str().expect("UTF8String should always return valid utf-8")
+    }
+}
+
+impl Drop for NSString {
+    fn drop(&mut self) {
+        unsafe { super::sys::avrs_foundation_release_object(self.0) }
+    }
+}


### PR DESCRIPTION
This adds a crate for working with AVFoundation – enough to capture video from your default video device.