### PR TITLE
use epoll instead of spawn_blocking for srt reads and writes

### DIFF
--- a/srt/src/async_lib.rs
+++ b/srt/src/async_lib.rs
@@ -1,12 +1,13 @@
 use super::{
-    check_code, listener_callback, new_io_error, sockaddr_from_storage, sys, to_sockaddr, ConnectOptions, Error, ListenerCallback, ListenerOption, Result,
-    Socket,
+    check_code, epoll_reactor::EpollReactor, listener_callback, new_io_error, sockaddr_from_storage, sys, to_sockaddr, ConnectOptions, Error, ListenerCallback,
+    ListenerOption, Result, Socket,
 };
 use std::{
     future::Future,
     io, mem,
     net::{SocketAddr, ToSocketAddrs},
     pin::Pin,
+    sync::Arc,
     task::{Context, Poll},
 };
 use tokio::{
@@ -89,13 +90,14 @@ impl<'a, 'c> Future for Accept<'a, 'c> {
             State::Idle => {
                 let sock = self.listener.socket.raw();
                 let api = self.listener.socket.api.clone();
+                // TODO: use epoll instead of spawn_blocking
                 let mut handle = spawn_blocking(move || {
                     let mut storage: sys::sockaddr_storage = unsafe { mem::zeroed() };
                     let mut len = mem::size_of_val(&storage) as sys::socklen_t;
                     let sock = unsafe { sys::srt_accept(sock, &mut storage as *mut _ as *mut _, &mut len as *mut _ as *mut _) };
                     let socket = Socket { api, sock };
                     let addr = sockaddr_from_storage(&storage, len)?;
-                    Ok((AsyncStream::new(socket.get(sys::SRT_SOCKOPT::STREAMID)?, socket), addr))
+                    Ok((AsyncStream::new(socket.get(sys::SRT_SOCKOPT::STREAMID)?, socket)?, addr))
                 });
                 let ret = Pin::new(&mut handle).poll(cx);
                 self.state = State::Busy(handle);
@@ -110,26 +112,21 @@ impl<'a, 'c> Future for Accept<'a, 'c> {
     }
 }
 
-enum IOState {
-    Idle(Option<Vec<u8>>),
-    Busy(JoinHandle<(Vec<u8>, io::Result<usize>)>),
-}
-
 pub struct AsyncStream {
+    epoll_reactor: Arc<EpollReactor>, // must be dropped before socket
     socket: Socket,
-    read_state: IOState,
-    write_state: IOState,
     id: Option<String>,
 }
 
 impl AsyncStream {
-    fn new(id: Option<String>, socket: Socket) -> Self {
-        Self {
-            id,
+    fn new(id: Option<String>, socket: Socket) -> Result<Self> {
+        socket.set(sys::SRT_SOCKOPT::SNDSYN, false)?;
+        socket.set(sys::SRT_SOCKOPT::RCVSYN, false)?;
+        Ok(Self {
+            epoll_reactor: socket.api.get_epoll_reactor()?,
             socket,
-            read_state: IOState::Idle(None),
-            write_state: IOState::Idle(None),
-        }
+            id,
+        })
     }
 
     pub async fn connect<A: ToSocketAddrs>(addr: A, options: &ConnectOptions) -> Result<Self> {
@@ -167,6 +164,7 @@ impl<'a> Future for Connect {
             State::Idle => {
                 let addr = self.addr;
                 let options = self.options.clone();
+                // TODO: use epoll instead of spawn_blocking
                 let mut handle = spawn_blocking(move || {
                     let (addr, len) = to_sockaddr(&addr);
                     let socket = Socket::new()?;
@@ -174,7 +172,7 @@ impl<'a> Future for Connect {
                     unsafe {
                         check_code("srt_connect", sys::srt_connect(socket.raw(), addr, len as _))?;
                     }
-                    Ok(AsyncStream::new(options.stream_id, socket))
+                    Ok(AsyncStream::new(options.stream_id, socket)?)
                 });
                 let ret = Pin::new(&mut handle).poll(cx);
                 self.state = State::Busy(handle);
@@ -190,82 +188,37 @@ impl<'a> Future for Connect {
 }
 
 impl AsyncRead for AsyncStream {
-    fn poll_read(mut self: Pin<&mut Self>, cx: &mut Context, buf: &mut ReadBuf) -> Poll<io::Result<()>> {
-        let poll = match &mut self.read_state {
-            IOState::Idle(ref mut recv_buf) => {
-                let mut recv_buf = match recv_buf.take() {
-                    Some(b) => b,
-                    None => Vec::new(),
-                };
-                recv_buf.resize(buf.remaining(), 0);
-                let sock = self.socket.raw();
-                let mut handle = spawn_blocking(move || {
-                    let r = match unsafe { sys::srt_recv(sock, recv_buf.as_mut_ptr() as *mut sys::char, recv_buf.len() as _) } {
-                        len if len >= 0 => Ok(len as usize),
-                        _ => Err(new_io_error("srt_recv")),
-                    };
-                    (recv_buf, r)
-                });
-                let poll = Pin::new(&mut handle).poll(cx);
-                self.read_state = IOState::Busy(handle);
-                poll
+    fn poll_read(self: Pin<&mut Self>, cx: &mut Context, buf: &mut ReadBuf) -> Poll<io::Result<()>> {
+        if let Ok(events) = self.socket.get::<i32>(sys::SRT_SOCKOPT::EVENT) {
+            if (events & sys::SRT_EPOLL_OPT::SRT_EPOLL_IN as i32) == 0 {
+                self.epoll_reactor.wake_when_read_ready(&self.socket, cx.waker().clone());
+                return Poll::Pending;
             }
-            IOState::Busy(handle) => Pin::new(handle).poll(cx),
-        };
-
-        match poll {
-            Poll::Ready(Ok((recv_buf, result))) => {
-                if let Ok(n) = result {
-                    let n = n.min(buf.remaining());
-                    buf.put_slice(&recv_buf[..n]);
-                }
-                self.read_state = IOState::Idle(Some(recv_buf));
-                Poll::Ready(result.map(|_| ()))
+        }
+        let sock = self.socket.raw();
+        match unsafe { sys::srt_recv(sock, buf.unfilled_mut().as_mut_ptr() as *mut sys::char, buf.remaining() as _) } {
+            len if len >= 0 => {
+                unsafe { buf.assume_init(len as _) };
+                buf.advance(len as _);
+                Poll::Ready(Ok(()))
             }
-            Poll::Ready(Err(join_error)) => {
-                self.read_state = IOState::Idle(None);
-                Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, format!("join error: {}", join_error))))
-            }
-            Poll::Pending => Poll::Pending,
+            _ => Poll::Ready(Err(new_io_error("srt_recv"))),
         }
     }
 }
 
 impl AsyncWrite for AsyncStream {
-    fn poll_write(mut self: Pin<&mut Self>, cx: &mut Context<'_>, src: &[u8]) -> Poll<io::Result<usize>> {
-        let poll = match &mut self.write_state {
-            IOState::Idle(ref mut send_buf) => {
-                let mut send_buf = match send_buf.take() {
-                    Some(b) => b,
-                    None => Vec::new(),
-                };
-                send_buf.resize(src.len(), 0);
-                send_buf.copy_from_slice(src);
-                let sock = self.socket.raw();
-                let mut handle = spawn_blocking(move || {
-                    let r = match unsafe { sys::srt_send(sock, send_buf.as_ptr() as *const sys::char, send_buf.len() as _) } {
-                        len if len >= 0 => Ok(len as usize),
-                        _ => Err(new_io_error("srt_send")),
-                    };
-                    (send_buf, r)
-                });
-                let poll = Pin::new(&mut handle).poll(cx);
-                self.write_state = IOState::Busy(handle);
-                poll
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, src: &[u8]) -> Poll<io::Result<usize>> {
+        if let Ok(events) = self.socket.get::<i32>(sys::SRT_SOCKOPT::EVENT) {
+            if (events & sys::SRT_EPOLL_OPT::SRT_EPOLL_OUT as i32) == 0 {
+                self.epoll_reactor.wake_when_write_ready(&self.socket, cx.waker().clone());
+                return Poll::Pending;
             }
-            IOState::Busy(handle) => Pin::new(handle).poll(cx),
-        };
-
-        match poll {
-            Poll::Ready(Ok((send_buf, result))) => {
-                self.write_state = IOState::Idle(Some(send_buf));
-                Poll::Ready(result)
-            }
-            Poll::Ready(Err(join_error)) => {
-                self.write_state = IOState::Idle(None);
-                Poll::Ready(Err(io::Error::new(io::ErrorKind::Other, format!("join error: {}", join_error))))
-            }
-            Poll::Pending => Poll::Pending,
+        }
+        let sock = self.socket.raw();
+        match unsafe { sys::srt_send(sock, src.as_ptr() as *const sys::char, src.len() as _) } {
+            len if len >= 0 => Poll::Ready(Ok(len as _)),
+            _ => Poll::Ready(Err(new_io_error("srt_send"))),
         }
     }
 
@@ -275,6 +228,12 @@ impl AsyncWrite for AsyncStream {
 
     fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<io::Result<()>> {
         Poll::Ready(Ok(()))
+    }
+}
+
+impl Drop for AsyncStream {
+    fn drop(&mut self) {
+        self.epoll_reactor.remove_socket(&self.socket);
     }
 }
 
@@ -291,19 +250,34 @@ mod test {
 
     #[tokio::test]
     async fn test_async_client_server() {
-        let listener = AsyncListener::bind("127.0.0.1:1235").unwrap();
+        let listener = AsyncListener::bind_with_options(
+            "127.0.0.1:1235",
+            [
+                ListenerOption::TimestampBasedPacketDeliveryMode(false),
+                ListenerOption::TooLatePacketDrop(false),
+            ]
+            .iter()
+            .cloned(),
+        )
+        .unwrap();
 
-        let options = &ConnectOptions::default();
-        let (accept_result, connect_result) = join!(listener.accept(), AsyncStream::connect("127.0.0.1:1235", options));
+        let options = ConnectOptions {
+            timestamp_based_packet_delivery_mode: Some(false),
+            too_late_packet_drop: Some(false),
+            ..Default::default()
+        };
+        let (accept_result, connect_result) = join!(listener.accept(), AsyncStream::connect("127.0.0.1:1235", &options));
         let mut server_conn = accept_result.unwrap().0;
         let mut client_conn = connect_result.unwrap();
         assert_eq!(client_conn.id(), None);
 
-        assert_eq!(client_conn.write(b"foo").await.unwrap(), 3);
-
         let mut buf = [0; 1316];
-        assert_eq!(server_conn.read(&mut buf).await.unwrap(), 3);
-        assert_eq!(&buf[0..3], b"foo");
+        for _ in 0..100 {
+            assert_eq!(client_conn.write(b"foo").await.unwrap(), 3);
+
+            assert_eq!(server_conn.read(&mut buf).await.unwrap(), 3);
+            assert_eq!(&buf[0..3], b"foo");
+        }
     }
 
     #[tokio::test]

--- a/srt/src/epoll_reactor.rs
+++ b/srt/src/epoll_reactor.rs
@@ -23,9 +23,9 @@ pub(crate) struct EpollReactor {
     wakers: Arc<Mutex<HashMap<sys::SRTSOCKET, Wakers>>>,
 }
 
-const READ_EVENTS: int = sys::SRT_EPOLL_OPT::SRT_EPOLL_ERR as int | sys::SRT_EPOLL_OPT::SRT_EPOLL_IN as int;
-const WRITE_EVENTS: int = sys::SRT_EPOLL_OPT::SRT_EPOLL_ERR as int | sys::SRT_EPOLL_OPT::SRT_EPOLL_OUT as int;
-const READ_WRITE_EVENTS: int = READ_EVENTS | WRITE_EVENTS;
+pub const READ_EVENTS: int = sys::SRT_EPOLL_OPT::SRT_EPOLL_ERR as int | sys::SRT_EPOLL_OPT::SRT_EPOLL_IN as int;
+pub const WRITE_EVENTS: int = sys::SRT_EPOLL_OPT::SRT_EPOLL_ERR as int | sys::SRT_EPOLL_OPT::SRT_EPOLL_OUT as int;
+pub const READ_WRITE_EVENTS: int = READ_EVENTS | WRITE_EVENTS;
 
 impl EpollReactor {
     pub fn new() -> Result<Self> {

--- a/srt/src/epoll_reactor.rs
+++ b/srt/src/epoll_reactor.rs
@@ -102,8 +102,8 @@ impl EpollReactor {
     fn run(eid: int, wakers: Arc<Mutex<HashMap<sys::SRTSOCKET, Wakers>>>, pipe: UnixStream) {
         unsafe { sys::srt_epoll_add_ssock(eid, pipe.into_raw_fd(), &READ_EVENTS) };
 
-        let mut readfds = [0; 10];
-        let mut writefds = [0; 10];
+        let mut readfds = [0; 200];
+        let mut writefds = [0; 200];
         let mut sys_readfds = [0; 1];
         let mut sys_writefds = [0; 1];
         loop {

--- a/srt/src/epoll_reactor.rs
+++ b/srt/src/epoll_reactor.rs
@@ -1,0 +1,198 @@
+use super::{new_srt_error, sys, Result, Socket};
+use libc::c_int as int;
+use std::{
+    collections::HashMap,
+    io::Write,
+    net,
+    os::unix::{io::IntoRawFd, net::UnixStream},
+    sync::{Arc, Mutex},
+    task::Waker,
+    thread,
+};
+
+#[derive(Default)]
+struct Wakers {
+    read_waker: Option<Waker>,
+    write_waker: Option<Waker>,
+}
+
+pub(crate) struct EpollReactor {
+    eid: int,
+    join_handle: Option<thread::JoinHandle<()>>,
+    pipe: UnixStream,
+    wakers: Arc<Mutex<HashMap<sys::SRTSOCKET, Wakers>>>,
+}
+
+const READ_EVENTS: int = sys::SRT_EPOLL_OPT::SRT_EPOLL_ERR as int | sys::SRT_EPOLL_OPT::SRT_EPOLL_IN as int;
+const WRITE_EVENTS: int = sys::SRT_EPOLL_OPT::SRT_EPOLL_ERR as int | sys::SRT_EPOLL_OPT::SRT_EPOLL_OUT as int;
+const READ_WRITE_EVENTS: int = READ_EVENTS | WRITE_EVENTS;
+
+impl EpollReactor {
+    pub fn new() -> Result<Self> {
+        let eid = match unsafe { sys::srt_epoll_create() } {
+            -1 => return Err(new_srt_error("srt_epoll_create")),
+            id => id,
+        };
+        let (pipe_a, pipe_b) = UnixStream::pair()?;
+        let wakers = Arc::new(Mutex::new(HashMap::new()));
+        Ok(Self {
+            eid,
+            pipe: pipe_a,
+            wakers: wakers.clone(),
+            join_handle: Some(thread::spawn(move || Self::run(eid, wakers, pipe_b))),
+        })
+    }
+
+    pub fn wake_when_read_ready(&self, s: &Socket, waker: Waker) {
+        let s = s.raw();
+        let mut wakers = self.wakers.lock().expect("the lock should not be poisoned");
+        match wakers.get_mut(&s) {
+            Some(prev) => {
+                let events = if prev.write_waker.is_some() { READ_WRITE_EVENTS } else { READ_EVENTS };
+                if prev.read_waker.is_none() {
+                    unsafe { sys::srt_epoll_update_usock(self.eid, s, &events as _) };
+                }
+                prev.read_waker = Some(waker);
+            }
+            None => {
+                wakers.insert(
+                    s,
+                    Wakers {
+                        read_waker: Some(waker),
+                        ..Default::default()
+                    },
+                );
+                unsafe { sys::srt_epoll_add_usock(self.eid, s, &READ_EVENTS) };
+            }
+        }
+    }
+
+    pub fn wake_when_write_ready(&self, s: &Socket, waker: Waker) {
+        let s = s.raw();
+        let mut wakers = self.wakers.lock().expect("the lock should not be poisoned");
+        match wakers.get_mut(&s) {
+            Some(prev) => {
+                let events = if prev.read_waker.is_some() { READ_WRITE_EVENTS } else { WRITE_EVENTS };
+                if prev.write_waker.is_none() {
+                    unsafe { sys::srt_epoll_update_usock(self.eid, s, &events as _) };
+                }
+                prev.write_waker = Some(waker);
+            }
+            None => {
+                wakers.insert(
+                    s,
+                    Wakers {
+                        write_waker: Some(waker),
+                        ..Default::default()
+                    },
+                );
+                unsafe { sys::srt_epoll_add_usock(self.eid, s, &WRITE_EVENTS) };
+            }
+        }
+    }
+
+    pub fn remove_socket(&self, s: &Socket) {
+        let s = s.raw();
+        let mut wakers = self.wakers.lock().expect("the lock should not be poisoned");
+        if wakers.remove(&s).is_some() {
+            unsafe { sys::srt_epoll_remove_usock(self.eid, s) };
+        }
+    }
+
+    fn run(eid: int, wakers: Arc<Mutex<HashMap<sys::SRTSOCKET, Wakers>>>, pipe: UnixStream) {
+        unsafe { sys::srt_epoll_add_ssock(eid, pipe.into_raw_fd(), &READ_EVENTS) };
+
+        let mut readfds = [0; 10];
+        let mut writefds = [0; 10];
+        let mut sys_readfds = [0; 1];
+        let mut sys_writefds = [0; 1];
+        loop {
+            let mut rnum = readfds.len() as int;
+            let mut wnum = writefds.len() as int;
+            let mut lrnum = sys_readfds.len() as int;
+            let mut lwnum = sys_writefds.len() as int;
+            unsafe {
+                sys::srt_epoll_wait(
+                    eid,
+                    readfds.as_mut_ptr(),
+                    &mut rnum as _,
+                    writefds.as_mut_ptr(),
+                    &mut wnum as _,
+                    -1,
+                    sys_readfds.as_mut_ptr(),
+                    &mut lrnum as _,
+                    sys_writefds.as_mut_ptr(),
+                    &mut lwnum as _,
+                )
+            };
+
+            if lrnum > 0 {
+                return;
+            }
+
+            if rnum > 0 || wnum > 0 {
+                let mut wakers = wakers.lock().expect("the lock should not be poisoned");
+                for &fd in &readfds[..readfds.len().min(rnum as _)] {
+                    match wakers.get_mut(&fd) {
+                        Some(fd_wakers) => {
+                            if let Some(waker) = fd_wakers.read_waker.take() {
+                                waker.wake();
+                            }
+                            if fd_wakers.write_waker.is_some() {
+                                unsafe { sys::srt_epoll_update_usock(eid, fd, &WRITE_EVENTS) };
+                            } else {
+                                wakers.remove(&fd);
+                                unsafe { sys::srt_epoll_remove_usock(eid, fd) };
+                            }
+                        }
+                        None => unsafe {
+                            sys::srt_epoll_remove_usock(eid, fd);
+                        },
+                    }
+                }
+                for &fd in &writefds[..writefds.len().min(wnum as _)] {
+                    match wakers.get_mut(&fd) {
+                        Some(fd_wakers) => {
+                            if let Some(waker) = fd_wakers.write_waker.take() {
+                                waker.wake();
+                            }
+                            if fd_wakers.read_waker.is_some() {
+                                unsafe { sys::srt_epoll_update_usock(eid, fd, &READ_EVENTS) };
+                            } else {
+                                wakers.remove(&fd);
+                                unsafe { sys::srt_epoll_remove_usock(eid, fd) };
+                            }
+                        }
+                        None => unsafe {
+                            sys::srt_epoll_remove_usock(eid, fd);
+                        },
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl Drop for EpollReactor {
+    fn drop(&mut self) {
+        self.pipe.write(b"x").expect("we should be able to write to the epoll thread pipe");
+        self.join_handle
+            .take()
+            .expect("there should be a join handle")
+            .join()
+            .expect("we should be able to join the epoll reactor thread");
+        self.pipe.shutdown(net::Shutdown::Both).expect("we should be able to shut down the pipe");
+        unsafe { sys::srt_epoll_release(self.eid) };
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_epoll_reactor() {
+        let reactor = EpollReactor::new();
+        std::mem::drop(reactor);
+    }
+}

--- a/srt/src/sys.rs
+++ b/srt/src/sys.rs
@@ -2,10 +2,28 @@ pub use libc::{c_char as char, c_int as int, c_void as void, sockaddr, sockaddr_
 
 pub type SRTSOCKET = int;
 
+#[cfg(feature = "async")]
+#[repr(C)]
+#[allow(non_camel_case_types)]
+pub enum SRT_EPOLL_OPT {
+    SRT_EPOLL_IN = 1,
+    SRT_EPOLL_OUT = 4,
+    SRT_EPOLL_ERR = 8,
+}
+
+#[cfg(feature = "async")]
+pub type SYSSOCKET = int;
+
 #[repr(C)]
 #[allow(non_camel_case_types)]
 pub enum SRT_SOCKOPT {
+    #[cfg(feature = "async")]
+    SNDSYN = 1,
+    #[cfg(feature = "async")]
+    RCVSYN = 2,
     RCVBUF = 6,
+    #[cfg(feature = "async")]
+    EVENT = 18,
     TSBPDMODE = 22,
     PASSPHRASE = 26,
     TLPKTDROP = 31,
@@ -41,5 +59,28 @@ extern "C" {
         lsn: SRTSOCKET,
         hook_fn: extern "C" fn(*mut void, SRTSOCKET, int, *const sockaddr, *const char) -> int,
         hook_opaque: *mut void,
+    ) -> int;
+}
+
+#[cfg(feature = "async")]
+#[link(name = "srt", kind = "static")]
+extern "C" {
+    pub fn srt_epoll_create() -> int;
+    pub fn srt_epoll_release(eid: int) -> int;
+    pub fn srt_epoll_add_ssock(eid: int, s: SYSSOCKET, events: *const int) -> int;
+    pub fn srt_epoll_add_usock(eid: int, s: SRTSOCKET, events: *const int) -> int;
+    pub fn srt_epoll_update_usock(eid: int, s: SRTSOCKET, events: *const int) -> int;
+    pub fn srt_epoll_remove_usock(eid: int, s: SRTSOCKET) -> int;
+    pub fn srt_epoll_wait(
+        eid: int,
+        readfds: *mut SRTSOCKET,
+        rnum: *mut int,
+        writefds: *mut SRTSOCKET,
+        wnum: *mut int,
+        ms_timeout: i64,
+        lrfds: *mut SYSSOCKET,
+        lrnum: *mut int,
+        lwfds: *mut SYSSOCKET,
+        lwnum: *mut int,
     ) -> int;
 }


### PR DESCRIPTION
This refactors asynchronous SRT reads and writes to use the SRT epoll API instead of `spawn_blocking`, which makes them several times faster and allows us to serve more streams as the Tokio runtime's max number of blocking threads will no longer be a bottleneck.

As a rough benchmark, if I up the iterations in the updated test to 50, this is the before:

```rust
running 1 test
test async_lib::test::test_async_client_server ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out; finished in 14.79s
```

And this is the after:

```rust
running 1 test
test async_lib::test::test_async_client_server ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 4 filtered out; finished in 5.70s
```

Epoll can potentially also be used to optimize the accept and connect APIs, but I'm marking those as TODOs as their performance isn't nearly as high a priority.