### PR TITLE
fix kCFStringEncodingUTF8 issue with newer bindgen

### DIFF
--- a/macos/core-foundation/build.rs
+++ b/macos/core-foundation/build.rs
@@ -13,7 +13,9 @@ fn main() {
             .header("src/lib.hpp")
             .whitelist_function("CF.+")
             .whitelist_var("kCFString.+")
+            .whitelist_type("CFStringBuiltInEncodings")
             .whitelist_type("OSStatus")
+            .prepend_enum_name(false)
             .generate()
             .expect("unable to generate bindings");
 


### PR DESCRIPTION
Not sure how you guys have been working around this issue, but this should make it go away.

Newer bindgen versions were generating the type for this enum differently. This makes it always generate it the old way.