### PR TITLE
move adts parsing to mpeg4 crate

### DIFF
--- a/mpeg4/src/lib.rs
+++ b/mpeg4/src/lib.rs
@@ -289,10 +289,10 @@ impl<'a> AudioDataTransportStream<'a> {
         if len < 7 || len > b.len() {
             return Err(io::Error::new(io::ErrorKind::UnexpectedEof, "invalid adts frame length"));
         }
-        let mpeg_version = if (b[1] & 0x08) == 1 {
-            AudioDataTransportStreamMPEGVersion::MPEG2
-        } else {
+        let mpeg_version = if (b[1] & 0x08) == 0 {
             AudioDataTransportStreamMPEGVersion::MPEG4
+        } else {
+            AudioDataTransportStreamMPEGVersion::MPEG2
         };
         let has_crc = (b[1] & 1) == 0;
         let mpeg4_audio_object_type = (b[2] >> 6) as u32 + 1;

--- a/mpegts-segmenter/Cargo.toml
+++ b/mpegts-segmenter/Cargo.toml
@@ -5,11 +5,11 @@ edition = "2018"
 
 [dependencies]
 mpeg2 = { path = "../mpeg2" }
+mpeg4 = { path = "../mpeg4" }
 h264 = { path = "../h264" }
 h265 = { path = "../h265" }
 rfc6381 = { path = "../rfc6381" }
 tokio = { version = "1.0", features = ["macros", "io-util", "fs", "rt-multi-thread"] }
-simple-error = "0.2.1"
 async-trait = "0.1.35"
 
 [dev-dependencies]

--- a/mpegts-segmenter/src/lib.rs
+++ b/mpegts-segmenter/src/lib.rs
@@ -1,9 +1,6 @@
 #[macro_use]
 extern crate async_trait;
 
-#[macro_use]
-extern crate simple_error;
-
 pub mod analyzer;
 pub use analyzer::*;
 


### PR DESCRIPTION
Cuts ADTS parsing from the MPEGTS analyzer and pastes it into the MPEG4 crate for reusability.