### PR TITLE
add audio queue volume setter

### DIFF
--- a/macos/audio-toolbox/build.rs
+++ b/macos/audio-toolbox/build.rs
@@ -15,6 +15,7 @@ fn main() {
             .clang_arg(format!("-isysroot{}", sdk_root))
             .header("src/lib.hpp")
             .whitelist_function("AudioQueue.+")
+            .whitelist_var("kAudioQueueParam_.+")
             .generate()
             .expect("unable to generate bindings");
 

--- a/macos/audio-toolbox/src/audio_queue.rs
+++ b/macos/audio-toolbox/src/audio_queue.rs
@@ -77,6 +77,11 @@ impl AudioQueue {
         result(unsafe { sys::AudioQueuePrime(self.inner, frames as _, &mut prepared as _).into() })?;
         Ok(prepared as _)
     }
+
+    /// Sets the volume. 0.0 is silent, 1.0 is full volume.
+    pub fn set_volume(&mut self, volume: f64) -> Result<(), OSStatus> {
+        result(unsafe { sys::AudioQueueSetParameter(self.inner, sys::kAudioQueueParam_Volume, volume as _).into() })
+    }
 }
 
 impl Drop for AudioQueue {
@@ -176,6 +181,7 @@ mod test {
             },
         )
         .unwrap();
+        queue.set_volume(0.0).unwrap();
 
         for _ in 0..3 {
             let mut buffer = queue.new_buffer(BUFFER_SIZE).unwrap();
@@ -211,6 +217,7 @@ mod test {
             |_buffer| {},
         )
         .unwrap();
+        queue.set_volume(0.0).unwrap();
 
         const BUFFER_SIZE: usize = 4096;
 


### PR DESCRIPTION
Adds a function to set the volume of an audio queue and uses it to silence the unit tests.