### PR TITLE
add audio encoder trait

### DIFF
--- a/av-traits/src/audio_encoder.rs
+++ b/av-traits/src/audio_encoder.rs
@@ -1,0 +1,44 @@
+use alloc::vec::Vec;
+
+pub struct RawAudioPacket<'a, S> {
+    pub samples: &'a [S],
+}
+
+pub struct EncodedAudioPacket {
+    pub data: Vec<u8>,
+}
+
+/// Implements basic audio encoding behavior.
+///
+/// Typical usage should look like this:
+///
+/// ```
+/// # use av_traits::{RawAudioPacket, AudioEncoder};
+/// fn encode<'a, S, E>(mut source: S, mut encoder: E) -> Result<(), E::Error>
+///     where S: Iterator<Item = RawAudioPacket<'a, u16>>,
+///     E: AudioEncoder<u16>
+/// {
+///     while let Some(packet) = source.next() {
+///         let output = encoder.encode(packet)?;
+///             // do something with output  
+///     }
+///
+///     Ok(())
+/// }
+/// ```
+pub trait AudioEncoder<S> {
+    type Error;
+
+    /// Encodes an audio packet.
+    fn encode(&mut self, packet: RawAudioPacket<S>) -> Result<EncodedAudioPacket, Self::Error>;
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_audio_encoder_object_safety() {
+        let _e: *const dyn AudioEncoder<u16, Error = ()>;
+    }
+}

--- a/av-traits/src/lib.rs
+++ b/av-traits/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
 extern crate alloc;
 
+mod audio_encoder;
+pub use audio_encoder::*;
+
 mod video_encoder;
 pub use video_encoder::*;


### PR DESCRIPTION
Adds an audio encoder trait on top of https://github.com/sportsball-ai/av-rs/pull/60.

Since audio encoding is cheap and simple enough that it's generally done on the CPU and synchronously, this is much simpler than the video encoding trait.