### PR TITLE
make mpeg2 no_std

### DIFF
--- a/mpeg2/Cargo.toml
+++ b/mpeg2/Cargo.toml
@@ -3,6 +3,10 @@ name = "mpeg2"
 version = "0.1.0"
 edition = "2018"
 
+[features]
+default = ["std"]
+std = ["core2/std"]
+
 [dependencies]
-simple-error = "0.2.1"
 crc = "2.0.0"
+core2 = { version = "0.4.0", features = ["alloc"] }

--- a/mpeg2/src/lib.rs
+++ b/mpeg2/src/lib.rs
@@ -1,5 +1,68 @@
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
+
 #[macro_use]
-extern crate simple_error;
+extern crate alloc;
+
+pub use core2::io;
+
+use core::fmt;
+
+#[derive(Debug)]
+pub struct DecodeError {
+    message: &'static str,
+}
+
+impl DecodeError {
+    pub fn new(message: &'static str) -> Self {
+        Self { message }
+    }
+}
+
+impl fmt::Display for DecodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for DecodeError {}
+
+#[derive(Debug)]
+pub enum EncodeError {
+    Io(io::Error),
+    Other(&'static str),
+}
+
+impl EncodeError {
+    pub fn other(message: &'static str) -> Self {
+        Self::Other(message)
+    }
+}
+
+impl From<io::Error> for EncodeError {
+    fn from(e: io::Error) -> Self {
+        Self::Io(e)
+    }
+}
+
+impl fmt::Display for EncodeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Io(e) => write!(f, "io error: {}", e),
+            Self::Other(msg) => write!(f, "{}", msg),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl std::error::Error for EncodeError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            Self::Io(e) => Some(e),
+            Self::Other(_) => None,
+        }
+    }
+}
 
 pub mod muxer;
 pub mod pes;

--- a/mpeg2/src/muxer.rs
+++ b/mpeg2/src/muxer.rs
@@ -1,8 +1,7 @@
-use super::{pes, ts};
-use std::{
-    cell::RefCell,
-    io::{Result, Write},
-};
+use super::{pes, ts, EncodeError};
+use alloc::vec::Vec;
+use core::cell::RefCell;
+use core2::io::Write;
 
 struct StreamState {
     stream_type: u8,
@@ -62,7 +61,7 @@ impl<W: Write> Muxer<W> {
         }
     }
 
-    fn write(&self, p: ts::Packet) -> Result<()> {
+    fn write(&self, p: ts::Packet) -> Result<(), EncodeError> {
         let mut state = self.state.borrow_mut();
 
         if !state.did_write_headers {
@@ -165,7 +164,7 @@ pub struct Stream<'a, W> {
 }
 
 impl<'a, W: Write> Stream<'a, W> {
-    pub fn write(&mut self, p: Packet) -> Result<()> {
+    pub fn write(&mut self, p: Packet) -> Result<(), EncodeError> {
         let pes_packet = pes::Packet {
             header: pes::PacketHeader {
                 stream_id: self.stream_id,

--- a/mpegts-segmenter/src/analyzer.rs
+++ b/mpegts-segmenter/src/analyzer.rs
@@ -338,7 +338,7 @@ impl Stream {
 
     pub fn flush(&mut self) -> Result<()> {
         if let Some(pes) = self.pes() {
-            for packet in pes.flush()? {
+            for packet in pes.flush() {
                 self.handle_pes_packet(packet)?;
             }
         }

--- a/mpegts-segmenter/src/segmenter.rs
+++ b/mpegts-segmenter/src/segmenter.rs
@@ -21,7 +21,8 @@ pub struct SegmenterConfig {
 
 #[derive(Debug)]
 pub enum Error {
-    IO(io::Error),
+    Io(io::Error),
+    Mpeg2Decode(mpeg2::DecodeError),
     Other(Box<dyn std::error::Error + Send + Sync>),
 }
 
@@ -30,7 +31,8 @@ impl std::error::Error for Error {}
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            Self::IO(e) => write!(f, "io error: {}", e),
+            Self::Io(e) => write!(f, "io error: {}", e),
+            Self::Mpeg2Decode(e) => write!(f, "mpeg2 decode error: {}", e),
             Self::Other(e) => e.fmt(f),
         }
     }
@@ -38,7 +40,13 @@ impl fmt::Display for Error {
 
 impl From<io::Error> for Error {
     fn from(e: io::Error) -> Self {
-        Self::IO(e)
+        Self::Io(e)
+    }
+}
+
+impl From<mpeg2::DecodeError> for Error {
+    fn from(e: mpeg2::DecodeError) -> Self {
+        Self::Mpeg2Decode(e)
     }
 }
 


### PR DESCRIPTION
This adds two new error types to `mpeg2`: `DecodeError` and `EncodeError`. All methods now return one of these errors instead of `Box<dyn Error>`.

This replaces `std::io` usage with `core2::io`, which is by default just a `pub use std::io`:

https://github.com/technocreatives/core2/blob/545e84bcb0f235b12e21351e0c69767958efe2a7/src/lib.rs#L17

And finally, this adds an "std" feature. This feature is enabled by default, but if you disable it, you can use the crate in `no_std` environments.