### PR TITLE
disable x264 bframes

### DIFF
--- a/av-traits/src/video_encoder.rs
+++ b/av-traits/src/video_encoder.rs
@@ -8,6 +8,7 @@ pub trait RawVideoFrame<S> {
 
 pub struct EncodedVideoFrame {
     pub data: Vec<u8>,
+    pub is_keyframe: bool,
 }
 
 pub struct VideoEncoderOutput<F> {

--- a/x264/src/encoder.rs
+++ b/x264/src/encoder.rs
@@ -57,6 +57,9 @@ impl<F> X264Encoder<F> {
             sys::x264_param_default(params.as_mut_ptr());
             let mut params = params.assume_init();
 
+            // disable b-frames to minimize latency and keep things simple
+            params.i_bframe = 0;
+
             params.i_csp = config.input_format.csp();
             params.i_width = config.width as _;
             params.i_height = config.height as _;
@@ -116,7 +119,10 @@ impl<F> X264Encoder<F> {
                     }
                     Ok(Some(VideoEncoderOutput {
                         raw_frame: *input,
-                        encoded_frame: EncodedVideoFrame { data },
+                        encoded_frame: EncodedVideoFrame {
+                            data,
+                            is_keyframe: pic_out.b_keyframe != 0,
+                        },
                     }))
                 }
             }


### PR DESCRIPTION
* Disables B-frames in the x264 encoder implementation. This is a more compatible and lower latency default, and we can add a config option to enable them later.
* Adds a field to the encoded output frame that indicates when it's a keyframe.