### PR TITLE
link libc for srt crate

### DIFF
--- a/srt/build.rs
+++ b/srt/build.rs
@@ -12,6 +12,7 @@ fn main() {
     #[cfg(target_os = "linux")]
     {
         println!("cargo:rustc-link-search={}/vendor/linux/lib", env!("CARGO_MANIFEST_DIR"));
+        println!("cargo:rustc-link-lib=c");
         println!("cargo:rustc-link-lib=stdc++");
         println!("cargo:rustc-link-lib=crypto");
     }


### PR DESCRIPTION
This seems to be required for certain build configurations.