### PR TITLE
Adds encoder to xilinx crate

### DIFF
--- a/xilinx/src/lib.rs
+++ b/xilinx/src/lib.rs
@@ -21,6 +21,16 @@ pub use xlnx_scal_props::*;
 pub mod xlnx_scal_utils;
 pub use xlnx_scal_utils::*;
 
+/*---- encoder ----*/
+pub mod xlnx_encoder;
+pub use xlnx_encoder::*;
+
+pub mod xlnx_enc_props;
+pub use xlnx_enc_props::*;
+
+pub mod xlnx_enc_utils;
+pub use xlnx_enc_utils::*;
+
 /*---- error ----*/
 pub mod xlnx_error;
 pub use xlnx_error::*;

--- a/xilinx/src/xlnx_enc_props.rs
+++ b/xilinx/src/xlnx_enc_props.rs
@@ -1,0 +1,372 @@
+use simple_error::{bail, SimpleError};
+
+use crate::{strcpy_to_arr_i8, sys::*};
+
+pub const MAX_ENC_PARAMS: usize = 3;
+
+const ENC_OPTIONS_PARAM_NAME: &[u8] = b"enc_options\0";
+const LATENCY_LOGGING_PARAM_NAME: &[u8] = b"latency_logging\0";
+const ENABLE_HW_IN_BUF_PARAM_NAME: &[u8] = b"enable_hw_in_buf\0";
+
+pub const ENC_H264_BASELINE: i32 = 66;
+pub const ENC_H264_MAIN: i32 = 77;
+pub const ENC_H264_HIGH: i32 = 100;
+pub const ENC_HEVC_MAIN: i32 = 0;
+pub const ENC_HEVC_MAIN_INTRA: i32 = 1;
+
+pub const CODEC_ID_HEVC: i32 = 1;
+pub const CODEC_ID_H264: i32 = 0;
+
+pub struct XlnxEncoderProperties {
+    pub cpb_size: f32,
+    pub initial_delay: f32,
+    pub max_bitrate: i64,
+    pub bit_rate: i64,
+    pub width: i32,
+    pub height: i32,
+    pub framerate: XmaFraction,
+    pub gop_size: i32,
+    pub slice_qp: i32,
+    pub min_qp: i32,
+    pub max_qp: i32,
+    pub codec_id: i32,
+    pub control_rate: i32,
+    pub custom_rc: i32,
+    pub gop_mode: i32,
+    pub gdr_mode: i32,
+    pub num_bframes: u32,
+    pub idr_period: u32,
+    pub profile: i32,
+    pub level: i32,
+    pub tier: i32,
+    pub num_slices: i32,
+    pub dependent_slice: bool,
+    pub slice_size: i32,
+    pub temporal_aq: i32,
+    pub spatial_aq: i32,
+    pub spatial_aq_gain: i32,
+    pub qp_mode: i32,
+    pub filler_data: bool,
+    pub aspect_ratio: i32,
+    pub scaling_list: i32,
+    pub entropy_mode: i32,
+    pub loop_filter: bool,
+    pub constrained_intra_pred: bool,
+    pub prefetch_buffer: bool,
+    pub tune_metrics: bool,
+    pub num_cores: i32,
+    pub latency_logging: i32,
+    pub enable_hw_buf: u32,
+    pub enc_options: String,
+    pub enc_options_ptr: *const u8,
+}
+
+fn xlnx_fill_enc_params(enc_props: &mut Box<XlnxEncoderProperties>, enc_params: &mut Box<[XmaParameter; MAX_ENC_PARAMS]>) {
+    enc_params[0].name = ENC_OPTIONS_PARAM_NAME.as_ptr() as *mut i8;
+    enc_params[0].type_ = XmaDataType_XMA_STRING;
+    enc_params[0].length = enc_props.enc_options.len() as u64;
+    enc_params[0].value = &enc_props.enc_options_ptr as *const _ as *mut std::ffi::c_void;
+
+    enc_params[1].name = LATENCY_LOGGING_PARAM_NAME.as_ptr() as *mut i8;
+    enc_params[1].type_ = XmaDataType_XMA_UINT32;
+    enc_params[1].length = 4;
+    enc_params[1].value = &mut enc_props.latency_logging as *mut _ as *mut std::ffi::c_void;
+
+    enc_params[2].name = ENABLE_HW_IN_BUF_PARAM_NAME.as_ptr() as *mut i8;
+    enc_params[2].type_ = XmaDataType_XMA_UINT32;
+    enc_params[2].length = 4;
+    enc_params[2].value = &mut enc_props.enable_hw_buf as *mut _ as *mut std::ffi::c_void;
+}
+
+pub fn xlnx_create_xma_enc_props(
+    enc_props: &mut Box<XlnxEncoderProperties>,
+    enc_params: &mut Box<[XmaParameter; MAX_ENC_PARAMS]>,
+) -> Result<Box<XmaEncoderProperties>, SimpleError> {
+    let xma_enc_props: XmaEncoderProperties = Default::default();
+    let mut xma_enc_props = Box::new(xma_enc_props);
+
+    strcpy_to_arr_i8(&mut xma_enc_props.hwvendor_string, "MPSoC")?;
+    xma_enc_props.hwencoder_type = XmaEncoderType_XMA_MULTI_ENCODER_TYPE;
+    xma_enc_props.param_cnt = MAX_ENC_PARAMS as u32;
+    xma_enc_props.params = enc_params.as_mut_ptr();
+    xma_enc_props.format = XmaFormatType_XMA_VCU_NV12_FMT_TYPE;
+    xma_enc_props.bits_per_pixel = 8;
+    xma_enc_props.width = enc_props.width;
+    xma_enc_props.height = enc_props.height;
+    xma_enc_props.rc_mode = 0;
+    xma_enc_props.framerate = enc_props.framerate;
+    xma_enc_props.lookahead_depth = 0;
+
+    // Begin filling encoder options
+    let rate_ctrl_mode = match enc_props.control_rate {
+        1 => "CBR",
+        2 => "VBR",
+        3 => "LOW_LATENCY",
+        _ => "CONST_QP",
+    };
+
+    let framerate = format!("{}/{}", enc_props.framerate.numerator, enc_props.framerate.denominator);
+
+    let slice_qp;
+    if enc_props.slice_qp == -1 {
+        slice_qp = "AUTO".to_string();
+    } else {
+        slice_qp = format!("{}", enc_props.slice_qp);
+    }
+
+    let gop_ctrl_mode = match enc_props.gop_mode {
+        1 => "PYRAMIDAL_GOP",
+        2 => "LOW_DELAY_P",
+        3 => "LOW_DELAY_B",
+        _ => "DEFAULT_GOP",
+    };
+
+    let gdr_mode = match enc_props.gdr_mode {
+        1 => "GDR_VERTICAL",
+        2 => "GDR_HORIZONTAL",
+        _ => "DISABLE",
+    };
+
+    let profile = match enc_props.codec_id {
+        // h264
+        CODEC_ID_H264 => match enc_props.profile {
+            ENC_H264_BASELINE => "AVC_BASELINE",
+            ENC_H264_MAIN => "AVC_MAIN",
+            ENC_H264_HIGH => "AVC_HIGH",
+            _ => bail!("invalid profile {} specified to H264 xlinx encoder", enc_props.profile),
+        },
+        // h265
+        CODEC_ID_HEVC => match enc_props.profile {
+            ENC_HEVC_MAIN => "HEVC_MAIN",
+            ENC_HEVC_MAIN_INTRA => "HEVC_MAIN_INTRA",
+            _ => bail!("invalid profile {} specified to HEVC xlinx encoder", enc_props.profile),
+        },
+        _ => bail!("incompatible codec_id {}", enc_props.codec_id),
+    };
+
+    let mut is_level_found = true;
+    let mut level = match enc_props.level {
+        10 => "1",
+        20 => "2",
+        21 => "2.1",
+        30 => "3",
+        31 => "3.1",
+        40 => "4",
+        41 => "4.1",
+        50 => "5",
+        51 => "5.1",
+        _ => {
+            is_level_found = false;
+            "1"
+        }
+    };
+
+    if !is_level_found {
+        match enc_props.codec_id {
+            CODEC_ID_H264 => {
+                level = match enc_props.level {
+                    11 => "1.1",
+                    12 => "1.2",
+                    13 => "1.3",
+                    22 => "2.2",
+                    32 => "3.2",
+                    42 => "4.2",
+                    52 => "5.2",
+                    _ => bail!("invalid H264 codec level value {}", enc_props.level),
+                }
+            }
+            CODEC_ID_HEVC => bail!("invalid HEVC codec level value{}", enc_props.level),
+            _ => {}
+        }
+    }
+
+    let tier = if enc_props.tier == 1 { "HIGH_TIER" } else { "MAIN_TIER" };
+
+    let mut qp_ctrl_mode = match enc_props.qp_mode {
+        1 => "UNIFORM_QP",
+        2 => "AUTO_QP",
+        _ => "LOAD_QP | RELATIVE_QP",
+    };
+
+    let dependent_slice = if enc_props.dependent_slice { "TRUE" } else { "FALSE" };
+
+    let filler_data = if enc_props.filler_data { "ENABLE" } else { "DISABLE" };
+
+    let aspect_ratio = match enc_props.aspect_ratio {
+        1 => "ASPECT_RATIO_4_3",
+        2 => "ASPECT_RATIO_16_9",
+        3 => "ASPECT_RATIO_NONE",
+        _ => "ASPECT_RATIO_AUTO",
+    };
+
+    let color_space = "COLOUR_DESC_UNSPECIFIED";
+
+    let mut scaling_list = if enc_props.scaling_list == 0 { "FLAT" } else { "DEFAULT" };
+
+    let loop_filter = if enc_props.loop_filter { "ENABLE" } else { "DISABLE" };
+
+    let entropy_mode = if enc_props.entropy_mode == 0 { "MODE_CAVLC" } else { "MODE_CABAC" };
+
+    let const_intra_pred = if enc_props.constrained_intra_pred { "ENABLE" } else { "DISABLE" };
+
+    let lambda_ctrl_mode = "DEFAULT_LDA";
+
+    let prefetch_buffer = if enc_props.prefetch_buffer { "ENABLE" } else { "DISABLE" };
+
+    if enc_props.tune_metrics {
+        scaling_list = "FLAT";
+        qp_ctrl_mode = "UNIFORM_QP";
+    }
+
+    let enc_options;
+    // hevc
+    if enc_props.codec_id == CODEC_ID_HEVC {
+        enc_options = format!("[INPUT]\n\
+        Width = {}\n\
+        Height = {}\n\
+        [RATE_CONTROL]\n\
+        RateCtrlMode = {}\n\
+        FrameRate = {}\n\
+        BitRate = {}\n\
+        MaxBitRate = {}\n\
+        SliceQP = {}\n\
+        MaxQP = {}\n\
+        MinQP = {}\n\
+        CPBSize = {}\n\
+        InitialDelay = {}\n\
+        [GOP]\n\
+        GopCtrlMode = {}\n\
+        Gop.GdrMode = {}\n\
+        Gop.Length = {}\n\
+        Gop.NumB = {}\n\
+        Gop.FreqIDR = {}\n\
+        [SETTINGS]\n\
+        Profile = {}\n\
+        Level = {}\n\
+        Tier = {}\n\
+        ChromaMode = CHROMA_4_2_0\n\
+        BitDepth = 8\n\
+        NumSlices = {}\n\
+        QPCtrlMode = {}\n\
+        SliceSize = {}\n\
+        DependentSlice = {}\n\
+        EnableFillerData = {}\n\
+        AspectRatio = {}\n\
+        ColourDescription = {}\n\
+        ScalingList = {}\n\
+        LoopFilter = {}\n\
+        ConstrainedIntraPred = {}\n\
+        LambdaCtrlMode = {}\n\
+        CacheLevel2 = {}\n\
+        NumCore = {}\n\0",
+            enc_props.width,
+            enc_props.height,
+            rate_ctrl_mode,
+            framerate,
+            enc_props.bit_rate,
+            enc_props.max_bitrate,
+            slice_qp,
+            enc_props.max_qp,
+            enc_props.min_qp,
+            enc_props.cpb_size,
+            enc_props.initial_delay,
+            gop_ctrl_mode,
+            gdr_mode,
+            enc_props.gop_size,
+            enc_props.num_bframes,
+            enc_props.idr_period,
+            profile,
+            level,
+            tier,
+            enc_props.num_slices,
+            qp_ctrl_mode,
+            enc_props.slice_size,
+            dependent_slice,
+            filler_data,
+            aspect_ratio,
+            color_space,
+            scaling_list,
+            loop_filter,
+            const_intra_pred,
+            lambda_ctrl_mode,
+            prefetch_buffer,
+            enc_props.num_cores
+        );
+    } else {
+        enc_options = format!("[INPUT]\n\
+        Width = {}\n\
+        Height = {}\n\
+        [RATE_CONTROL]\n\
+        RateCtrlMode = {}\n\
+        FrameRate = {}\n\
+        BitRate = {}\n\
+        MaxBitRate = {}\n\
+        SliceQP = {}\n\
+        MaxQP = {}\n\
+        MinQP = {}\n\
+        CPBSize = {}\n\
+        InitialDelay = {}\n\
+        [GOP]\n\
+        GopCtrlMode = {}\n\
+        Gop.GdrMode = {}\n\
+        Gop.Length = {}\n\
+        Gop.NumB = {}\n\
+        Gop.FreqIDR = {}\n\
+        [SETTINGS]\n\
+        Profile = {}\n\
+        Level = {}\n\
+        ChromaMode = CHROMA_4_2_0\n\
+        BitDepth = 8\n\
+        NumSlices = {}\n\
+        QPCtrlMode = {}\n\
+        SliceSize = {}\n\
+        EnableFillerData = {}\n\
+        AspectRatio = {}\n\
+        ColourDescription = {}\n\
+        ScalingList = {}\n\
+        EntropyMode = {}\n\
+        LoopFilter = {}\n\
+        ConstrainedIntraPred = {}\n\
+        LambdaCtrlMode = {}\n\
+        CacheLevel2 = {}\n\
+        NumCore = {}\n\0",
+            enc_props.width,
+            enc_props.height,
+            rate_ctrl_mode,
+            framerate,
+            enc_props.bit_rate,
+            enc_props.max_bitrate,
+            slice_qp,
+            enc_props.max_qp,
+            enc_props.min_qp,
+            enc_props.cpb_size,
+            enc_props.initial_delay,
+            gop_ctrl_mode,
+            gdr_mode,
+            enc_props.gop_size,
+            enc_props.num_bframes,
+            enc_props.idr_period,
+            profile,
+            level,
+            enc_props.num_slices,
+            qp_ctrl_mode,
+            enc_props.slice_size,
+            filler_data,
+            aspect_ratio,
+            color_space,
+            scaling_list,
+            entropy_mode,
+            loop_filter,
+            const_intra_pred,
+            lambda_ctrl_mode,
+            prefetch_buffer,
+            enc_props.num_cores
+        );
+    }
+
+    enc_props.enc_options = enc_options;
+    enc_props.enc_options_ptr = enc_props.enc_options.as_ptr();
+    xlnx_fill_enc_params(enc_props, enc_params);
+
+    Ok(xma_enc_props)
+}

--- a/xilinx/src/xlnx_enc_props.rs
+++ b/xilinx/src/xlnx_enc_props.rs
@@ -107,12 +107,11 @@ pub fn xlnx_create_xma_enc_props(
 
     let framerate = format!("{}/{}", enc_props.framerate.numerator, enc_props.framerate.denominator);
 
-    let slice_qp;
-    if enc_props.slice_qp == -1 {
-        slice_qp = "AUTO".to_string();
+    let slice_qp = if enc_props.slice_qp == -1 {
+        "AUTO".to_string()
     } else {
-        slice_qp = format!("{}", enc_props.slice_qp);
-    }
+        format!("{}", enc_props.slice_qp)
+    };
 
     let gop_ctrl_mode = match enc_props.gop_mode {
         1 => "PYRAMIDAL_GOP",
@@ -218,151 +217,103 @@ pub fn xlnx_create_xma_enc_props(
         qp_ctrl_mode = "UNIFORM_QP";
     }
 
-    let enc_options;
-    // hevc
-    if enc_props.codec_id == CODEC_ID_HEVC {
-        enc_options = format!("[INPUT]\n\
-        Width = {}\n\
-        Height = {}\n\
+    let width = enc_props.width;
+    let height = enc_props.height;
+    let bit_rate = enc_props.bit_rate;
+    let max_bitrate = enc_props.max_bitrate;
+    let max_qp = enc_props.max_qp;
+    let min_qp = enc_props.min_qp;
+    let cpb_size = enc_props.cpb_size;
+    let initial_delay = enc_props.initial_delay;
+    let gop_size = enc_props.gop_size;
+    let num_bframes = enc_props.num_bframes;
+    let idr_period = enc_props.idr_period;
+    let num_slices = enc_props.num_slices;
+    let slice_size = enc_props.slice_size;
+    let num_cores = enc_props.num_cores;
+
+    let enc_options = if enc_props.codec_id == CODEC_ID_HEVC {
+        format!(
+            "[INPUT]\n\
+        Width = {width}\n\
+        Height = {height}\n\
         [RATE_CONTROL]\n\
-        RateCtrlMode = {}\n\
-        FrameRate = {}\n\
-        BitRate = {}\n\
-        MaxBitRate = {}\n\
-        SliceQP = {}\n\
-        MaxQP = {}\n\
-        MinQP = {}\n\
-        CPBSize = {}\n\
-        InitialDelay = {}\n\
+        RateCtrlMode = {rate_ctrl_mode}\n\
+        FrameRate = {framerate}\n\
+        BitRate = {bit_rate}\n\
+        MaxBitRate = {max_bitrate}\n\
+        SliceQP = {slice_qp}\n\
+        MaxQP = {max_qp}\n\
+        MinQP = {min_qp}\n\
+        CPBSize = {cpb_size}\n\
+        InitialDelay = {initial_delay}\n\
         [GOP]\n\
-        GopCtrlMode = {}\n\
-        Gop.GdrMode = {}\n\
-        Gop.Length = {}\n\
-        Gop.NumB = {}\n\
-        Gop.FreqIDR = {}\n\
+        GopCtrlMode = {gop_ctrl_mode}\n\
+        Gop.GdrMode = {gdr_mode}\n\
+        Gop.Length = {gop_size}\n\
+        Gop.NumB = {num_bframes}\n\
+        Gop.FreqIDR = {idr_period}\n\
         [SETTINGS]\n\
-        Profile = {}\n\
-        Level = {}\n\
-        Tier = {}\n\
+        Profile = {profile}\n\
+        Level = {level}\n\
+        Tier = {tier}\n\
         ChromaMode = CHROMA_4_2_0\n\
         BitDepth = 8\n\
-        NumSlices = {}\n\
-        QPCtrlMode = {}\n\
-        SliceSize = {}\n\
-        DependentSlice = {}\n\
-        EnableFillerData = {}\n\
-        AspectRatio = {}\n\
-        ColourDescription = {}\n\
-        ScalingList = {}\n\
-        LoopFilter = {}\n\
-        ConstrainedIntraPred = {}\n\
-        LambdaCtrlMode = {}\n\
-        CacheLevel2 = {}\n\
-        NumCore = {}\n\0",
-            enc_props.width,
-            enc_props.height,
-            rate_ctrl_mode,
-            framerate,
-            enc_props.bit_rate,
-            enc_props.max_bitrate,
-            slice_qp,
-            enc_props.max_qp,
-            enc_props.min_qp,
-            enc_props.cpb_size,
-            enc_props.initial_delay,
-            gop_ctrl_mode,
-            gdr_mode,
-            enc_props.gop_size,
-            enc_props.num_bframes,
-            enc_props.idr_period,
-            profile,
-            level,
-            tier,
-            enc_props.num_slices,
-            qp_ctrl_mode,
-            enc_props.slice_size,
-            dependent_slice,
-            filler_data,
-            aspect_ratio,
-            color_space,
-            scaling_list,
-            loop_filter,
-            const_intra_pred,
-            lambda_ctrl_mode,
-            prefetch_buffer,
-            enc_props.num_cores
-        );
+        NumSlices = {num_slices}\n\
+        QPCtrlMode = {qp_ctrl_mode}\n\
+        SliceSize = {slice_size}\n\
+        DependentSlice = {dependent_slice}\n\
+        EnableFillerData = {filler_data}\n\
+        AspectRatio = {aspect_ratio}\n\
+        ColourDescription = {color_space}\n\
+        ScalingList = {scaling_list}\n\
+        LoopFilter = {loop_filter}\n\
+        ConstrainedIntraPred = {const_intra_pred}\n\
+        LambdaCtrlMode = {lambda_ctrl_mode}\n\
+        CacheLevel2 = {prefetch_buffer}\n\
+        NumCore = {num_cores}\n\0"
+        )
     } else {
-        enc_options = format!("[INPUT]\n\
-        Width = {}\n\
-        Height = {}\n\
+        format!(
+            "[INPUT]\n\
+        Width = {width}\n\
+        Height = {height}\n\
         [RATE_CONTROL]\n\
-        RateCtrlMode = {}\n\
-        FrameRate = {}\n\
-        BitRate = {}\n\
-        MaxBitRate = {}\n\
-        SliceQP = {}\n\
-        MaxQP = {}\n\
-        MinQP = {}\n\
-        CPBSize = {}\n\
-        InitialDelay = {}\n\
+        RateCtrlMode = {rate_ctrl_mode}\n\
+        FrameRate = {framerate}\n\
+        BitRate = {bit_rate}\n\
+        MaxBitRate = {max_bitrate}\n\
+        SliceQP = {slice_qp}\n\
+        MaxQP = {max_qp}\n\
+        MinQP = {min_qp}\n\
+        CPBSize = {cpb_size}\n\
+        InitialDelay = {initial_delay}\n\
         [GOP]\n\
-        GopCtrlMode = {}\n\
-        Gop.GdrMode = {}\n\
-        Gop.Length = {}\n\
-        Gop.NumB = {}\n\
-        Gop.FreqIDR = {}\n\
+        GopCtrlMode = {gop_ctrl_mode}\n\
+        Gop.GdrMode = {gdr_mode}\n\
+        Gop.Length = {gop_size}\n\
+        Gop.NumB = {num_bframes}\n\
+        Gop.FreqIDR = {idr_period}\n\
         [SETTINGS]\n\
-        Profile = {}\n\
-        Level = {}\n\
+        Profile = {profile}\n\
+        Level = {level}\n\
         ChromaMode = CHROMA_4_2_0\n\
         BitDepth = 8\n\
-        NumSlices = {}\n\
-        QPCtrlMode = {}\n\
-        SliceSize = {}\n\
-        EnableFillerData = {}\n\
-        AspectRatio = {}\n\
-        ColourDescription = {}\n\
-        ScalingList = {}\n\
-        EntropyMode = {}\n\
-        LoopFilter = {}\n\
-        ConstrainedIntraPred = {}\n\
-        LambdaCtrlMode = {}\n\
-        CacheLevel2 = {}\n\
-        NumCore = {}\n\0",
-            enc_props.width,
-            enc_props.height,
-            rate_ctrl_mode,
-            framerate,
-            enc_props.bit_rate,
-            enc_props.max_bitrate,
-            slice_qp,
-            enc_props.max_qp,
-            enc_props.min_qp,
-            enc_props.cpb_size,
-            enc_props.initial_delay,
-            gop_ctrl_mode,
-            gdr_mode,
-            enc_props.gop_size,
-            enc_props.num_bframes,
-            enc_props.idr_period,
-            profile,
-            level,
-            enc_props.num_slices,
-            qp_ctrl_mode,
-            enc_props.slice_size,
-            filler_data,
-            aspect_ratio,
-            color_space,
-            scaling_list,
-            entropy_mode,
-            loop_filter,
-            const_intra_pred,
-            lambda_ctrl_mode,
-            prefetch_buffer,
-            enc_props.num_cores
-        );
-    }
+        NumSlices = {num_slices}\n\
+        QPCtrlMode = {qp_ctrl_mode}\n\
+        SliceSize = {slice_size}\n\
+        EnableFillerData = {filler_data}\n\
+        AspectRatio = {aspect_ratio}\n\
+        ColourDescription = {color_space}\n\
+        ScalingList = {scaling_list}\n\
+        EntropyMode = {entropy_mode}\n\
+        LoopFilter = {loop_filter}\n\
+        ConstrainedIntraPred = {const_intra_pred}\n\
+        LambdaCtrlMode = {lambda_ctrl_mode}\n\
+        CacheLevel2 = {prefetch_buffer}\n\
+        NumCore = {num_cores}\n\0"
+        )
+    };
 
     enc_props.enc_options = enc_options;
     enc_props.enc_options_ptr = enc_props.enc_options.as_ptr();

--- a/xilinx/src/xlnx_enc_utils.rs
+++ b/xilinx/src/xlnx_enc_utils.rs
@@ -1,0 +1,236 @@
+use crate::{strcpy_to_arr_i8, sys::*, xrm_precision_1000000_bitmask};
+use libloading::{Library, Symbol};
+use simple_error::{bail, SimpleError};
+use std::{ffi::CString, os::raw::c_char, str::from_utf8};
+
+pub struct XlnxEncoderXrmCtx {
+    pub xrm_reserve_id: u64,
+    pub device_id: i32,
+    pub enc_load: i32,
+    pub encode_res_in_use: bool,
+    pub xrm_ctx: xrmContext,
+    pub cu_list_res: xrmCuListResource,
+}
+
+/// Calculates the encoder load uing the xrmU30Enc plugin.
+pub fn xlnx_calc_enc_load(xrm_ctx: xrmContext, xma_enc_props: *mut XmaEncoderProperties) -> Result<i32, SimpleError> {
+    let func_id = 0;
+    let mut plugin_param: xrmPluginFuncParam = Default::default();
+    unsafe {
+        match Library::new("/opt/xilinx/xrm/plugin/libxmaPropsTOjson.so") {
+            Ok(lib) => {
+                match lib
+                    .get::<Symbol<extern "C" fn(props: *mut XmaEncoderProperties, function: *const c_char, json_params: *mut c_char)>>(b"convertXmaPropsToJson")
+                {
+                    Ok(convert_xma_props_to_json) => {
+                        let function = CString::new("ENCODER").unwrap();
+                        convert_xma_props_to_json(xma_enc_props, function.as_ptr(), plugin_param.input.as_mut_ptr());
+                    }
+                    Err(e) => bail!("{}", e),
+                }
+            }
+            Err(e) => bail!("{}", e),
+        };
+    }
+
+    let plugin_name = CString::new("xrmU30EncPlugin").unwrap().into_raw();
+
+    unsafe {
+        let ret = xrmExecPluginFunc(xrm_ctx, plugin_name, func_id, &mut plugin_param);
+        if ret != XRM_SUCCESS as i32 {
+            bail!("XRM encoder plugin failed to calculate encoder load. error: {}", ret);
+        }
+    }
+    // parse the load from the output buffer of plugin param.
+    let output_bytes = &plugin_param.output.map(|i| i as u8);
+    let enc_plugin_output = from_utf8(output_bytes)
+        .unwrap_or("-1")
+        .split(' ')
+        .next()
+        .expect("split should emit at least one item");
+    let load = enc_plugin_output.parse::<i32>().unwrap_or(-1);
+
+    if load == -1 {
+        bail!("unable to parse load calculation from XRM encoder plugin");
+    }
+
+    Ok(load)
+}
+
+fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolProperty, enc_count: i32, enc_load: i32) -> Result<(), SimpleError> {
+    cu_pool_prop.cuListProp.sameDevice = true;
+    cu_pool_prop.cuListNum = 1;
+    let mut cu_num = 0;
+
+    strcpy_to_arr_i8(&mut cu_pool_prop.cuListProp.cuProps[cu_num].kernelName, "encoder")?;
+    strcpy_to_arr_i8(&mut cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "ENCODER_MPSOC")?;
+    cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
+    cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(enc_load);
+    cu_num += 1;
+
+    for _ in 0..enc_count {
+        strcpy_to_arr_i8(&mut cu_pool_prop.cuListProp.cuProps[cu_num].kernelName, "kernel_vcu_encoder")?;
+
+        cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
+        cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
+        cu_num += 1
+    }
+    // we defined 2 cu requests to the properties.
+    cu_pool_prop.cuListProp.cuNum = cu_num as i32;
+
+    Ok(())
+}
+
+pub fn xlnx_reserve_enc_resource(xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
+    // a device has already been chosen, there is no need to assign a reserve id.
+    if xlnx_enc_ctx.device_id >= 0 {
+        return Ok(());
+    }
+
+    let enc_count = 1;
+    let mut cu_pool_prop: xrmCuPoolProperty = Default::default();
+    xlnx_fill_enc_pool_props(&mut cu_pool_prop, enc_count, xlnx_enc_ctx.enc_load)?;
+
+    unsafe {
+        let num_cu_pool = xrmCheckCuPoolAvailableNum(xlnx_enc_ctx.xrm_ctx, &mut cu_pool_prop);
+        if num_cu_pool <= 0 {
+            bail!("no encoder resources avaliable for allocation")
+        }
+
+        xlnx_enc_ctx.xrm_reserve_id = xrmCuPoolReserve(xlnx_enc_ctx.xrm_ctx, &mut cu_pool_prop);
+        if xlnx_enc_ctx.xrm_reserve_id == 0 {
+            bail!("failed to reserve encode cu pool")
+        }
+    }
+
+    Ok(())
+}
+
+/// Allocates encoder CU based on device_id
+fn xlnx_enc_cu_alloc_device_id(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
+    let mut encode_cu_hw_prop: xrmCuProperty = Default::default();
+    let mut encode_cu_sw_prop: xrmCuProperty = Default::default();
+
+    strcpy_to_arr_i8(&mut encode_cu_hw_prop.kernelName, "encoder")?;
+    strcpy_to_arr_i8(&mut encode_cu_hw_prop.kernelAlias, "ENCODER_MPSOC")?;
+    encode_cu_hw_prop.devExcl = false;
+    encode_cu_hw_prop.requestLoad = xrm_precision_1000000_bitmask(xlnx_enc_ctx.enc_load);
+
+    strcpy_to_arr_i8(&mut encode_cu_sw_prop.kernelName, "kernel_vcu_encoder")?;
+    encode_cu_sw_prop.devExcl = false;
+    encode_cu_sw_prop.requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
+
+    let ret = unsafe {
+        xrmCuAllocFromDev(
+            xlnx_enc_ctx.xrm_ctx,
+            xlnx_enc_ctx.device_id,
+            &mut encode_cu_hw_prop,
+            &mut xlnx_enc_ctx.cu_list_res.cuResources[0],
+        )
+    };
+    if ret <= XRM_ERROR {
+        bail!("xrm failed to allocate encoder resources on device: {}", xlnx_enc_ctx.device_id);
+    }
+
+    let ret = unsafe {
+        xrmCuAllocFromDev(
+            xlnx_enc_ctx.xrm_ctx,
+            xlnx_enc_ctx.device_id,
+            &mut encode_cu_sw_prop,
+            &mut xlnx_enc_ctx.cu_list_res.cuResources[1],
+        )
+    };
+    if ret <= XRM_ERROR {
+        bail!("xrm failed to allocate encoder resources on device: {}", xlnx_enc_ctx.device_id);
+    }
+    xlnx_enc_ctx.encode_res_in_use = true;
+
+    // Set XMA plugin shared object and device index.
+    xma_enc_props.plugin_lib = xlnx_enc_ctx.cu_list_res.cuResources[0].kernelPluginFileName.as_mut_ptr();
+    xma_enc_props.dev_index = xlnx_enc_ctx.cu_list_res.cuResources[0].deviceId;
+
+    // Select ddr bank based on xclbin metadata.
+    xma_enc_props.ddr_bank_index = -1;
+    xma_enc_props.cu_index = xlnx_enc_ctx.cu_list_res.cuResources[1].cuId;
+    xma_enc_props.channel_id = xlnx_enc_ctx.cu_list_res.cuResources[1].channelId;
+
+    Ok(())
+}
+
+/// Allocated encoder CU based on reserve_id
+fn xlnx_enc_cu_alloc_reserve_id(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
+    // Allocate xrm encoder cu
+    let mut encode_cu_list_prop = xrmCuListProperty {
+        cuNum: 2,
+        ..Default::default()
+    };
+
+    strcpy_to_arr_i8(&mut encode_cu_list_prop.cuProps[0].kernelName, "encoder")?;
+    strcpy_to_arr_i8(&mut encode_cu_list_prop.cuProps[0].kernelAlias, "ENCODER_MPSOC")?;
+    encode_cu_list_prop.cuProps[0].devExcl = false;
+    encode_cu_list_prop.cuProps[0].requestLoad = xrm_precision_1000000_bitmask(xlnx_enc_ctx.enc_load);
+    encode_cu_list_prop.cuProps[0].poolId = xlnx_enc_ctx.xrm_reserve_id;
+
+    strcpy_to_arr_i8(&mut encode_cu_list_prop.cuProps[1].kernelName, "kernel_vcu_encoder")?;
+    encode_cu_list_prop.cuProps[1].devExcl = false;
+    encode_cu_list_prop.cuProps[1].requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
+    encode_cu_list_prop.cuProps[1].poolId = xlnx_enc_ctx.xrm_reserve_id;
+
+    if unsafe { xrmCuListAlloc(xlnx_enc_ctx.xrm_ctx, &mut encode_cu_list_prop, &mut xlnx_enc_ctx.cu_list_res) } != 0 {
+        bail!("failed to allocate encode cu list from reserve id {}", xlnx_enc_ctx.xrm_reserve_id)
+    }
+    xlnx_enc_ctx.encode_res_in_use = true;
+
+    // Set XMA plugin shared object and device index.
+    xma_enc_props.plugin_lib = xlnx_enc_ctx.cu_list_res.cuResources[0].kernelPluginFileName.as_mut_ptr();
+    xma_enc_props.dev_index = xlnx_enc_ctx.cu_list_res.cuResources[0].deviceId;
+
+    // Select ddr bank based on xclbin metadata.
+    xma_enc_props.ddr_bank_index = -1;
+    xma_enc_props.cu_index = xlnx_enc_ctx.cu_list_res.cuResources[1].cuId;
+    xma_enc_props.channel_id = xlnx_enc_ctx.cu_list_res.cuResources[1].channelId;
+
+    Ok(())
+}
+
+fn xlnx_enc_cu_alloc(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
+    if xlnx_enc_ctx.device_id >= 0 {
+        xlnx_enc_cu_alloc_device_id(xma_enc_props, xlnx_enc_ctx)?;
+    } else {
+        xlnx_enc_cu_alloc_reserve_id(xma_enc_props, xlnx_enc_ctx)?;
+    }
+
+    Ok(())
+}
+
+/// Attempts to creat encoder session
+pub(crate) fn xlnx_create_enc_session(
+    xma_enc_props: &mut XmaEncoderProperties,
+    xlnx_enc_ctx: &mut XlnxEncoderXrmCtx,
+) -> Result<*mut XmaEncoderSession, SimpleError> {
+    xlnx_enc_cu_alloc(xma_enc_props, xlnx_enc_ctx)?;
+
+    let enc_session = unsafe { xma_enc_session_create(xma_enc_props) };
+    if enc_session.is_null() {
+        bail!("failed to create encoder session. Session is null");
+    }
+
+    Ok(enc_session)
+}
+
+impl Drop for XlnxEncoderXrmCtx {
+    fn drop(&mut self) {
+        if self.xrm_ctx.is_null() {
+            return;
+        }
+        unsafe {
+            if self.encode_res_in_use {
+                xrmCuListRelease(self.xrm_ctx, &mut self.cu_list_res);
+            }
+            if self.xrm_reserve_id != 0 {
+                xrmCuPoolRelinquish(self.xrm_ctx, self.xrm_reserve_id);
+            }
+            xrmDestroyContext(self.xrm_ctx);
+        }
+    }
+}

--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -1,0 +1,252 @@
+use crate::{sys::*, xlnx_enc_utils::*, xlnx_error::*};
+use simple_error::SimpleError;
+
+pub struct XlnxEncoder {
+    enc_session: *mut XmaEncoderSession,
+    out_buffer: *mut XmaDataBuffer,
+    flush_frame_sent: bool,
+}
+
+impl XlnxEncoder {
+    pub fn new(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<Self, SimpleError> {
+        xlnx_reserve_enc_resource(xlnx_enc_ctx)?;
+
+        let enc_session = xlnx_create_enc_session(xma_enc_props, xlnx_enc_ctx)?;
+
+        let out_buffer = unsafe { xma_data_buffer_alloc(0, true) };
+
+        Ok(Self {
+            enc_session,
+            out_buffer,
+            flush_frame_sent: false,
+        })
+    }
+
+    /// Sends raw frames to Xilinx Encoder plugin and receives back decoded frames.  
+    pub fn process_frame(&mut self, enc_in_frame: *mut XmaFrame, enc_null_frame: bool, enc_out_size: &mut i32) -> Result<(), XlnxError> {
+
+        if !self.flush_frame_sent {
+            match self.send_frame(enc_in_frame) {
+                Ok(_) => {},
+                Err(e) => {
+                    if enc_null_frame {
+                        self.flush_frame_sent = true;
+                    }
+                    return Err(e);
+                }
+            }
+        }
+
+        match self.recv_frame(enc_out_size) {
+            Ok(_) => {
+                if enc_null_frame {
+                    self.flush_frame_sent = true;
+                }
+                Ok(())
+            }
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Sends raw frames to the encoder to be processed
+    fn send_frame(&mut self, frame: *mut XmaFrame) -> Result<(), XlnxError> {
+        unsafe {
+            let ret = xma_enc_session_send_frame(self.enc_session, frame);
+            if ret == XMA_ERROR {
+                let handle: XvbmBufferHandle = (*frame).data[0].buffer;
+                if !handle.is_null() {
+                    xvbm_buffer_pool_entry_free(handle);
+                }
+            }
+
+            if ret != XMA_SUCCESS as i32 {
+                return Err(XlnxError::new(ret, Some("error sending frame to encoder".to_string())));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Receives encoded frames from encoder. 
+    fn recv_frame(&mut self, enc_out_size: &mut i32) -> Result<(), XlnxError> {
+        let ret = unsafe { xma_enc_session_recv_data(self.enc_session, self.out_buffer, enc_out_size) };
+        if ret != XMA_SUCCESS as i32 {
+            return Err(XlnxError::new(ret, Some("error receiving frame from encoder".to_string())));
+        }
+
+        Ok(())
+    }
+}
+
+impl Drop for XlnxEncoder {
+    fn drop(&mut self) {
+        unsafe {
+            if !self.enc_session.is_null() {
+                xma_enc_session_destroy(self.enc_session);
+            }
+            if !self.out_buffer.is_null() {
+                xma_data_buffer_free(self.out_buffer);
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod encoder_tests {
+    use crate::{tests::*, xlnx_enc_props::*, xlnx_enc_utils::*, xlnx_encoder::*};
+
+    fn encode_raw(codec_id: i32, profile: i32, level: i32) -> i32 {
+        let mut frame_props = XmaFrameProperties {
+            format: XmaFormatType_XMA_YUV420_FMT_TYPE,
+            width: 1280,
+            height: 720,
+            bits_per_pixel: 8,
+            ..Default::default()
+        };
+
+        // read the raw yuv into xma_frames, This file has 300 frames.
+        let (xma_frames, _y_component, _x_component) = read_raw_yuv_420_p(RAW_YUV_P_FILE_PATH, &mut frame_props, 300);
+
+        initialize();
+
+        // create a Xlnx encoder's context
+        let mut enc_props = Box::new(XlnxEncoderProperties {
+            cpb_size: 2.0,
+            initial_delay: 1.0,
+            max_bitrate: 4000,
+            bit_rate: 4000,
+            width: 1280,
+            height: 720,
+            framerate: XmaFraction{numerator: 1, denominator: 25},
+            gop_size: 120,
+            slice_qp: -1,
+            min_qp: 0,
+            max_qp: 51,
+            codec_id,
+            control_rate: 1,
+            custom_rc: 0,
+            gop_mode: 0,
+            gdr_mode: 0,
+            num_bframes: 2,
+            idr_period: 120,
+            profile,
+            level,
+            tier: 0,
+            num_slices: 1,
+            dependent_slice: false,
+            slice_size: 0,
+            temporal_aq: 1,
+            spatial_aq: 1,
+            spatial_aq_gain: 50,
+            qp_mode: 1,
+            filler_data: false,
+            aspect_ratio: 2,
+            scaling_list: 1,
+            entropy_mode: 1,
+            loop_filter: true,
+            constrained_intra_pred: false,
+            prefetch_buffer: true,
+            tune_metrics: false,
+            num_cores: 0,
+            latency_logging: 1,
+            enable_hw_buf: 0,
+            enc_options: String::new(),
+            enc_options_ptr: std::ptr::null(),
+        });
+
+        let enc_params: [XmaParameter; MAX_ENC_PARAMS] = Default::default();
+        let mut enc_params = Box::new(enc_params);
+
+        let mut xma_enc_props = xlnx_create_xma_enc_props(&mut enc_props, &mut enc_params).unwrap();
+
+        let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
+
+        let cu_list_res: xrmCuListResource = Default::default();
+        let enc_load = xlnx_calc_enc_load(xrm_ctx, &mut *xma_enc_props).unwrap();
+
+        let mut xlnx_enc_ctx = XlnxEncoderXrmCtx {
+            xrm_reserve_id: 0,
+            device_id: -1,
+            enc_load,
+            encode_res_in_use: false,
+            xrm_ctx,
+            cu_list_res,
+        };
+
+        // create xlnx encoder
+        let mut encoder = XlnxEncoder::new(&mut *xma_enc_props, &mut xlnx_enc_ctx).unwrap();
+
+        let mut processed_frame_count = 0;
+
+        for xma_frame in xma_frames {
+            let mut enc_out_size = 0;
+            match encoder.process_frame(xma_frame, false, &mut enc_out_size) {
+                Ok(_) => {
+                    if enc_out_size > 0 {
+                        //successfully encoded frame 
+                        processed_frame_count += 1;
+                    } else {
+                        panic!("no data received from encoder")
+                    }
+                }
+                Err(e) => match e.err {
+                    XlnxErrorType::XlnxSendMoreData => {}, 
+                    XlnxErrorType::XlnxTryAgain => {},
+                    _ => panic!("encoder processing has failed with error {:?}", e),
+                }
+            }
+        }
+        
+        //allocate a null frame without a buffer to start flushing
+        let null_frame = unsafe { xma_frame_alloc(&mut frame_props, true) };
+        loop {
+            let mut enc_out_size = 0;
+            unsafe {
+                (*null_frame).is_last_frame = 1;
+                (*null_frame).pts = u64::MAX;
+            }
+
+            match encoder.process_frame(null_frame, true, & mut enc_out_size) {
+                Ok(_) => {
+                    processed_frame_count += 1;
+                    break
+                }, // if flush was successful the first time, break
+                Err(e) => match e.err {
+                    XlnxErrorType::XlnxFlushAgain => {},
+                    XlnxErrorType::XlnxEOS => break,
+                    _ => panic!("error sending flush frame to encoder {:?}", e),
+                }
+            }
+        }
+        //free the null frame
+        unsafe { xma_frame_free(null_frame) };
+        
+        
+        loop {
+            let mut enc_out_size = 0;
+            match encoder.recv_frame(&mut enc_out_size) {
+                Ok(_) => {processed_frame_count += 1;},
+                Err(e) => match e.err {
+                    XlnxErrorType::XlnxEOS => break, //we have hit the end of the stream, 
+                    XlnxErrorType::XlnxTryAgain => {},
+                    _ => panic!("error receiving frame while flushing {:?}", e),
+                }
+            }
+        }
+
+        processed_frame_count
+
+    }
+    
+    #[test]
+    fn test_hevc_encode() {
+        let processed_frame_count = encode_raw(CODEC_ID_HEVC, ENC_HEVC_MAIN, 31);
+        assert_eq!(processed_frame_count, 300);
+    }
+
+    #[test]
+    fn test_h264_encode() {
+        let processed_frame_count = encode_raw(CODEC_ID_H264, ENC_H264_BASELINE, 31);
+        assert_eq!(processed_frame_count, 300);
+    }
+}


### PR DESCRIPTION
This implements the Xilinx encoder API.

Steps to test:
Begin with a server or machine with the xilinx u30 acceleration cards.

- install xilinx video sdk.
- run xilinx setup script : source /opt/xilinx/xcdr/setup.sh
- set env LD_LIBRARY_PATH=/opt/xilinx/xrm/lib:/opt/xilinx/xrt/lib
- cargo test