### PR TITLE
add video toolbox encoder

### DIFF
--- a/macos/core-foundation/build.rs
+++ b/macos/core-foundation/build.rs
@@ -16,6 +16,7 @@ fn main() {
             .header("src/lib.hpp")
             .whitelist_function("CF.+")
             .whitelist_var("kCFString.+")
+            .whitelist_var("kCFBoolean.+")
             .whitelist_type("CFStringBuiltInEncodings")
             .whitelist_type("OSStatus")
             .prepend_enum_name(false)

--- a/macos/core-foundation/src/array.rs
+++ b/macos/core-foundation/src/array.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate as core_foundation;
 
 pub struct Array(sys::CFArrayRef);
 crate::trait_impls!(Array);

--- a/macos/core-foundation/src/array.rs
+++ b/macos/core-foundation/src/array.rs
@@ -1,0 +1,26 @@
+use super::*;
+use crate as core_foundation;
+
+pub struct Array(sys::CFArrayRef);
+crate::trait_impls!(Array);
+
+impl Array {
+    pub fn len(&self) -> usize {
+        unsafe { sys::CFArrayGetCount(self.0) as _ }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// # Safety
+    /// Behavior is undefined if the value is not of type `T` or if the index is out of range.
+    pub unsafe fn cf_type_value_at_index<T: CFType>(&self, idx: usize) -> Option<T> {
+        let v = sys::CFArrayGetValueAtIndex(self.0, idx as _);
+        if v.is_null() {
+            None
+        } else {
+            Some(T::with_cf_type_ref(v as _))
+        }
+    }
+}

--- a/macos/core-foundation/src/boolean.rs
+++ b/macos/core-foundation/src/boolean.rs
@@ -1,0 +1,22 @@
+use super::*;
+use crate as core_foundation;
+
+pub struct Boolean(sys::CFBooleanRef);
+crate::trait_impls!(Boolean);
+
+impl Boolean {
+    pub fn value(&self) -> bool {
+        unsafe { sys::CFBooleanGetValue(self.0) != 0 }
+    }
+}
+
+impl From<bool> for Boolean {
+    fn from(b: bool) -> Self {
+        unsafe {
+            Self::with_cf_type_ref(match b {
+                true => sys::kCFBooleanTrue,
+                false => sys::kCFBooleanFalse,
+            } as _)
+        }
+    }
+}

--- a/macos/core-foundation/src/boolean.rs
+++ b/macos/core-foundation/src/boolean.rs
@@ -19,3 +19,17 @@ impl From<bool> for Boolean {
         }
     }
 }
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_boolean() {
+        let b = Boolean::from(true);
+        assert!(b.value());
+
+        let b = Boolean::from(false);
+        assert!(!b.value());
+    }
+}

--- a/macos/core-foundation/src/boolean.rs
+++ b/macos/core-foundation/src/boolean.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate as core_foundation;
 
 pub struct Boolean(sys::CFBooleanRef);
 crate::trait_impls!(Boolean);

--- a/macos/core-foundation/src/dictionary.rs
+++ b/macos/core-foundation/src/dictionary.rs
@@ -1,5 +1,4 @@
 use super::*;
-use crate as core_foundation;
 use std::os::raw::c_void;
 
 pub struct Dictionary(sys::CFDictionaryRef);

--- a/macos/core-foundation/src/dictionary.rs
+++ b/macos/core-foundation/src/dictionary.rs
@@ -1,0 +1,49 @@
+use super::*;
+use crate as core_foundation;
+use std::os::raw::c_void;
+
+pub struct Dictionary(sys::CFDictionaryRef);
+crate::trait_impls!(Dictionary);
+
+impl Dictionary {
+    /// # Safety
+    /// Behavior is undefined if the value is not of type `T`.
+    pub unsafe fn cf_type_value<T: CFType>(&self, key: *const c_void) -> Option<T> {
+        let mut v = std::ptr::null();
+        if sys::CFDictionaryGetValueIfPresent(self.0, key, &mut v as *mut _ as _) != 0 {
+            Some(T::with_cf_type_ref(v as _))
+        } else {
+            None
+        }
+    }
+}
+
+pub struct MutableDictionary(sys::CFMutableDictionaryRef);
+crate::trait_impls!(MutableDictionary);
+
+impl Default for MutableDictionary {
+    fn default() -> Self {
+        unsafe {
+            Self(sys::CFDictionaryCreateMutable(
+                std::ptr::null_mut(),
+                0,
+                std::ptr::null_mut(),
+                std::ptr::null_mut(),
+            ))
+        }
+    }
+}
+
+impl MutableDictionary {
+    /// # Safety
+    /// Behavior is undefined if the key and value are not of the expected type.
+    pub unsafe fn set_value(&mut self, key: *const c_void, value: *const c_void) {
+        sys::CFDictionarySetValue(self.0, key, value);
+    }
+}
+
+impl From<MutableDictionary> for Dictionary {
+    fn from(desc: MutableDictionary) -> Self {
+        unsafe { Self::with_cf_type_ref(desc.0 as _) }
+    }
+}

--- a/macos/core-foundation/src/lib.rs
+++ b/macos/core-foundation/src/lib.rs
@@ -29,26 +29,26 @@ macro_rules! trait_impls {
     ($e:ident) => {
         impl std::fmt::Debug for $e {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-                use core_foundation::CFType;
+                use $crate::CFType;
                 write!(f, "{}", self.description().unwrap_or("{..}".to_string()))
             }
         }
 
         impl Drop for $e {
             fn drop(&mut self) {
-                unsafe { core_foundation::sys::CFRelease(self.0 as _) }
+                unsafe { $crate::sys::CFRelease(self.0 as _) }
             }
         }
 
         unsafe impl Send for $e {}
 
-        impl core_foundation::CFType for $e {
-            unsafe fn with_cf_type_ref(cf: core_foundation::sys::CFTypeRef) -> Self {
-                core_foundation::sys::CFRetain(cf);
+        impl $crate::CFType for $e {
+            unsafe fn with_cf_type_ref(cf: $crate::sys::CFTypeRef) -> Self {
+                $crate::sys::CFRetain(cf);
                 Self(cf as _)
             }
 
-            unsafe fn cf_type_ref(&self) -> core_foundation::sys::CFTypeRef {
+            unsafe fn cf_type_ref(&self) -> $crate::sys::CFTypeRef {
                 self.0 as _
             }
         }

--- a/macos/core-foundation/src/lib.rs
+++ b/macos/core-foundation/src/lib.rs
@@ -15,6 +15,15 @@ pub mod sys {
 pub mod base;
 pub use base::*;
 
+pub mod array;
+pub use array::*;
+
+pub mod boolean;
+pub use boolean::*;
+
+pub mod dictionary;
+pub use dictionary::*;
+
 #[macro_export]
 macro_rules! trait_impls {
     ($e:ident) => {

--- a/macos/core-media/build.rs
+++ b/macos/core-media/build.rs
@@ -18,6 +18,7 @@ fn main() {
             .whitelist_function("CMBlockBuffer.+")
             .whitelist_function("CMSampleBuffer.+")
             .whitelist_var("kCFAllocator.+")
+            .whitelist_var("kCMVideoCodecType_.+")
             .generate()
             .expect("unable to generate bindings");
 

--- a/macos/core-media/src/block_buffer.rs
+++ b/macos/core-media/src/block_buffer.rs
@@ -27,4 +27,41 @@ impl BlockBuffer {
         )?;
         Ok(Self(ret))
     }
+
+    pub fn create_contiguous(&self, offset: usize, len: usize) -> Result<Self, OSStatus> {
+        unsafe {
+            let mut ret = std::ptr::null_mut();
+            result(
+                sys::CMBlockBufferCreateContiguous(
+                    std::ptr::null(), // structureAllocator
+                    self.0,
+                    std::ptr::null(), // blockAllocator
+                    std::ptr::null(), // customBlockSource
+                    offset as _,
+                    len as _,
+                    0,
+                    &mut ret as _,
+                )
+                .into(),
+            )?;
+            Ok(Self(ret))
+        }
+    }
+
+    pub fn data(&self, offset: usize) -> Result<&[u8], OSStatus> {
+        let mut ptr = std::ptr::null_mut();
+        let mut len = 0;
+        unsafe {
+            result(sys::CMBlockBufferGetDataPointer(self.0, offset as _, &mut len, std::ptr::null_mut(), &mut ptr).into())?;
+            Ok(std::slice::from_raw_parts(ptr as _, len as _))
+        }
+    }
+
+    pub fn data_len(&self) -> usize {
+        unsafe { sys::CMBlockBufferGetDataLength(self.0) as _ }
+    }
+
+    pub fn copy_data_bytes(&self, offset: usize, dest: &mut [u8]) -> Result<(), OSStatus> {
+        unsafe { result(sys::CMBlockBufferCopyDataBytes(self.0, offset as _, dest.len() as _, dest.as_mut_ptr() as _).into()) }
+    }
 }

--- a/macos/core-media/src/lib.rs
+++ b/macos/core-media/src/lib.rs
@@ -13,6 +13,12 @@ pub mod sys {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
+pub mod video_codec_type;
+pub use video_codec_type::*;
+
+pub mod time;
+pub use time::*;
+
 pub mod format_description;
 pub use format_description::*;
 

--- a/macos/core-media/src/sample_buffer.rs
+++ b/macos/core-media/src/sample_buffer.rs
@@ -5,9 +5,9 @@ pub struct SampleBuffer(sys::CMSampleBufferRef);
 core_foundation::trait_impls!(SampleBuffer);
 
 impl SampleBuffer {
-    pub fn new<T: FormatDescription>(
+    pub fn new(
         block_buffer: &BlockBuffer,
-        format_description: Option<&T>,
+        format_description: Option<FormatDescription>,
         num_samples: usize,
         sample_sizes: Option<&[usize]>,
     ) -> Result<Self, OSStatus> {
@@ -48,6 +48,39 @@ impl SampleBuffer {
                 None
             } else {
                 Some(core_video::ImageBuffer::with_cf_type_ref(buf as _))
+            }
+        }
+    }
+
+    pub fn attachments_array(&self) -> Option<core_foundation::Array> {
+        unsafe {
+            let buf = sys::CMSampleBufferGetSampleAttachmentsArray(self.0, 0);
+            if buf.is_null() {
+                None
+            } else {
+                Some(core_foundation::Array::with_cf_type_ref(buf as _))
+            }
+        }
+    }
+
+    pub fn data_buffer(&self) -> Option<BlockBuffer> {
+        unsafe {
+            let buf = sys::CMSampleBufferGetDataBuffer(self.0);
+            if buf.is_null() {
+                None
+            } else {
+                Some(BlockBuffer::with_cf_type_ref(buf as _))
+            }
+        }
+    }
+
+    pub fn format_description(&self) -> Option<FormatDescription> {
+        unsafe {
+            let buf = sys::CMSampleBufferGetFormatDescription(self.0);
+            if buf.is_null() {
+                None
+            } else {
+                Some(FormatDescription::with_cf_type_ref(buf as _))
             }
         }
     }

--- a/macos/core-media/src/time.rs
+++ b/macos/core-media/src/time.rs
@@ -1,0 +1,20 @@
+use super::sys;
+
+#[derive(Clone, Debug, Default)]
+pub struct Time {
+    pub value: i64,
+    pub timescale: i32,
+    pub flags: u32,
+    pub epoch: i64,
+}
+
+impl From<Time> for sys::CMTime {
+    fn from(t: Time) -> Self {
+        Self {
+            value: t.value,
+            timescale: t.timescale,
+            epoch: t.epoch,
+            flags: t.flags,
+        }
+    }
+}

--- a/macos/core-media/src/video_codec_type.rs
+++ b/macos/core-media/src/video_codec_type.rs
@@ -1,0 +1,56 @@
+use super::sys;
+
+#[derive(Clone, Copy, Debug)]
+pub enum VideoCodecType {
+    AppleProRes422,
+    AppleProRes422Hq,
+    AppleProRes422Lt,
+    AppleProRes422Proxy,
+    AppleProRes4444,
+    AppleProRes4444Xq,
+    AppleProResRaw,
+    AppleProResRawHq,
+    Animation,
+    Cinepak,
+    Jpeg,
+    JpegOpenDml,
+    SorensonVideo,
+    SorensonVideo3,
+    H263,
+    H264,
+    Hevc,
+    HevcWithAlpha,
+    Mpeg4Video,
+    Mpeg2Video,
+    Mpeg1Video,
+    Vp9,
+}
+
+impl From<VideoCodecType> for sys::CMVideoCodecType {
+    fn from(t: VideoCodecType) -> Self {
+        match t {
+            VideoCodecType::AppleProRes422 => sys::kCMVideoCodecType_AppleProRes422,
+            VideoCodecType::AppleProRes422Hq => sys::kCMVideoCodecType_AppleProRes422HQ,
+            VideoCodecType::AppleProRes422Lt => sys::kCMVideoCodecType_AppleProRes422LT,
+            VideoCodecType::AppleProRes422Proxy => sys::kCMVideoCodecType_AppleProRes422Proxy,
+            VideoCodecType::AppleProRes4444 => sys::kCMVideoCodecType_AppleProRes4444,
+            VideoCodecType::AppleProRes4444Xq => sys::kCMVideoCodecType_AppleProRes4444XQ,
+            VideoCodecType::AppleProResRaw => sys::kCMVideoCodecType_AppleProResRAW,
+            VideoCodecType::AppleProResRawHq => sys::kCMVideoCodecType_AppleProResRAWHQ,
+            VideoCodecType::Animation => sys::kCMVideoCodecType_Animation,
+            VideoCodecType::Cinepak => sys::kCMVideoCodecType_Cinepak,
+            VideoCodecType::Jpeg => sys::kCMVideoCodecType_JPEG,
+            VideoCodecType::JpegOpenDml => sys::kCMVideoCodecType_JPEG_OpenDML,
+            VideoCodecType::SorensonVideo => sys::kCMVideoCodecType_SorensonVideo,
+            VideoCodecType::SorensonVideo3 => sys::kCMVideoCodecType_SorensonVideo3,
+            VideoCodecType::H263 => sys::kCMVideoCodecType_H263,
+            VideoCodecType::H264 => sys::kCMVideoCodecType_H264,
+            VideoCodecType::Hevc => sys::kCMVideoCodecType_HEVC,
+            VideoCodecType::HevcWithAlpha => sys::kCMVideoCodecType_HEVCWithAlpha,
+            VideoCodecType::Mpeg4Video => sys::kCMVideoCodecType_MPEG4Video,
+            VideoCodecType::Mpeg2Video => sys::kCMVideoCodecType_MPEG2Video,
+            VideoCodecType::Mpeg1Video => sys::kCMVideoCodecType_MPEG1Video,
+            VideoCodecType::Vp9 => sys::kCMVideoCodecType_VP9,
+        }
+    }
+}

--- a/macos/video-toolbox/Cargo.toml
+++ b/macos/video-toolbox/Cargo.toml
@@ -9,6 +9,7 @@ build = "build.rs"
 bindgen = "0.*"
 
 [dependencies]
+av-traits = { path = "../../av-traits" }
 core-foundation = { path = "../core-foundation" }
 core-media = { path = "../core-media" }
 core-video = { path = "../core-video" }

--- a/macos/video-toolbox/build.rs
+++ b/macos/video-toolbox/build.rs
@@ -14,7 +14,13 @@ fn main() {
         let bindings = bindgen::Builder::default()
             .clang_arg(format!("-isysroot{}", sdk_root))
             .header("src/lib.hpp")
+            .whitelist_function("VTCompressionSession.+")
             .whitelist_function("VTDecompressionSession.+")
+            .whitelist_var("kCMTime.+")
+            .whitelist_var("kCVPixelFormatType_.+")
+            .whitelist_var("kCMSampleAttachmentKey_.+")
+            .whitelist_var("kVTVideoEncoderSpecification_.+")
+            .whitelist_var("kVTCompressionPropertyKey_.+")
             .generate()
             .expect("unable to generate bindings");
 

--- a/macos/video-toolbox/src/compression_session.rs
+++ b/macos/video-toolbox/src/compression_session.rs
@@ -1,0 +1,185 @@
+use super::sys;
+use core_foundation::{result, CFType, Dictionary, OSStatus};
+use core_media::{SampleBuffer, Time, VideoCodecType};
+use core_video::ImageBuffer;
+use std::{
+    marker::{PhantomData, PhantomPinned},
+    pin::Pin,
+    sync::mpsc,
+};
+
+struct CallbackContext<C> {
+    frames: mpsc::Sender<Result<CompressionSessionOutputFrame<C>, OSStatus>>,
+    _pinned: PhantomPinned,
+}
+
+pub struct CompressionSessionOutputFrame<C> {
+    pub sample_buffer: SampleBuffer,
+    pub context: C,
+}
+
+pub struct CompressionSession<C: Send> {
+    sess: sys::VTCompressionSessionRef,
+    frames: mpsc::Receiver<Result<CompressionSessionOutputFrame<C>, OSStatus>>,
+    _callback_context: Pin<Box<CallbackContext<C>>>,
+    _frame_context: PhantomData<C>,
+}
+
+#[derive(Debug)]
+pub struct CompressionSessionConfig {
+    pub width: i32,
+    pub height: i32,
+    pub codec_type: VideoCodecType,
+    pub encoder_specification: Option<Dictionary>,
+}
+
+impl<C: Send> CompressionSession<C> {
+    pub fn new(config: CompressionSessionConfig) -> Result<Self, OSStatus> {
+        let (tx, rx) = mpsc::channel();
+
+        let callback_context = Box::pin(CallbackContext {
+            frames: tx,
+            _pinned: PhantomPinned,
+        });
+
+        unsafe extern "C" fn callback<C>(
+            output_callback_ref_con: *mut std::os::raw::c_void,
+            source_frame_ref_con: *mut std::os::raw::c_void,
+            status: sys::OSStatus,
+            _info_flags: sys::VTDecodeInfoFlags,
+            sample_buffer: sys::CMSampleBufferRef,
+        ) {
+            let ctx = &*(output_callback_ref_con as *mut CallbackContext<C>);
+            let frame_context = *Box::<C>::from_raw(source_frame_ref_con as *mut C);
+            let _ = ctx.frames.send(if sample_buffer.is_null() {
+                Err(status.into())
+            } else {
+                result(status.into()).map(|_| CompressionSessionOutputFrame {
+                    sample_buffer: unsafe { SampleBuffer::with_cf_type_ref(sample_buffer as _) },
+                    context: frame_context,
+                })
+            });
+        }
+
+        let mut sess = std::ptr::null_mut();
+        result(
+            unsafe {
+                sys::VTCompressionSessionCreate(
+                    std::ptr::null_mut(),
+                    config.width,
+                    config.height,
+                    config.codec_type.into(),
+                    match &config.encoder_specification {
+                        Some(dict) => dict.cf_type_ref() as _,
+                        None => std::ptr::null(),
+                    },
+                    std::ptr::null(),
+                    std::ptr::null(),
+                    Some(callback::<C>),
+                    &*callback_context as *const _ as *mut _,
+                    &mut sess as _,
+                )
+            }
+            .into(),
+        )?;
+        Ok(Self {
+            sess,
+            frames: rx,
+            _callback_context: callback_context,
+            _frame_context: PhantomData,
+        })
+    }
+
+    pub fn frames(&self) -> &mpsc::Receiver<Result<CompressionSessionOutputFrame<C>, OSStatus>> {
+        &self.frames
+    }
+
+    pub fn encode_frame(&mut self, image_buffer: ImageBuffer, presentation_time: Time, context: C) -> Result<(), OSStatus> {
+        let context = Box::new(context);
+        result(
+            unsafe {
+                sys::VTCompressionSessionEncodeFrame(
+                    self.sess,
+                    image_buffer.cf_type_ref() as _,
+                    sys::CMTime {
+                        value: presentation_time.value,
+                        timescale: presentation_time.timescale,
+                        flags: presentation_time.flags,
+                        epoch: presentation_time.epoch,
+                    },
+                    sys::kCMTimeInvalid,
+                    std::ptr::null_mut(),
+                    Box::into_raw(context) as *mut C as _,
+                    std::ptr::null_mut(),
+                )
+            }
+            .into(),
+        )
+    }
+
+    pub fn flush(&mut self) -> Result<(), OSStatus> {
+        result(
+            unsafe {
+                sys::VTCompressionSessionCompleteFrames(
+                    self.sess,
+                    sys::CMTime {
+                        value: 0,
+                        timescale: 0,
+                        flags: 0,
+                        epoch: 0,
+                    },
+                )
+            }
+            .into(),
+        )
+    }
+}
+
+impl<C: Send> Drop for CompressionSession<C> {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::{super::DecompressionSession, *};
+    use core_media::VideoFormatDescription;
+    use std::{fs::File, io::Read};
+
+    #[test]
+    fn test_compression_session() {
+        let mut f = File::open("src/testdata/smptebars.h264").unwrap();
+        let mut buf = Vec::new();
+        f.read_to_end(&mut buf).unwrap();
+
+        let nalus: Vec<_> = h264::iterate_annex_b(&buf).collect();
+        let format_desc = VideoFormatDescription::with_h264_parameter_sets(&[nalus[0], nalus[1]], 4).unwrap();
+        let mut decompression_session = DecompressionSession::new(&format_desc).unwrap();
+        let mut compression_session = CompressionSession::new(CompressionSessionConfig {
+            width: 1280,
+            height: 720,
+            codec_type: VideoCodecType::H264,
+            encoder_specification: None,
+        })
+        .unwrap();
+
+        // This file is encoded as exactly one NALU per frame.
+        let mut frames_sent = 0;
+        for nalu in &nalus[3..10] {
+            let mut frame_data = vec![0, 0, (nalu.len() / 256) as u8, nalu.len() as u8];
+            frame_data.extend_from_slice(nalu);
+            let image_buffer = decompression_session.decode_frame(&frame_data, &format_desc).unwrap();
+            frames_sent += 1;
+            compression_session.encode_frame(image_buffer, Time::default(), ()).unwrap();
+        }
+        compression_session.flush().unwrap();
+
+        let mut frame_count = 0;
+        while let Ok(frame) = compression_session.frames().try_recv() {
+            frame.unwrap();
+            frame_count += 1;
+        }
+        assert_eq!(frame_count, frames_sent);
+    }
+}

--- a/macos/video-toolbox/src/decompression_session.rs
+++ b/macos/video-toolbox/src/decompression_session.rs
@@ -56,7 +56,7 @@ impl DecompressionSession {
         result(
             unsafe {
                 let block_buffer = BlockBuffer::with_memory_block(frame_data)?;
-                let sample_buffer = SampleBuffer::new(&block_buffer, Some(format_desc), 1, Some(&[frame_data.len()]))?;
+                let sample_buffer = SampleBuffer::new(&block_buffer, Some(format_desc.into()), 1, Some(&[frame_data.len()]))?;
                 sys::VTDecompressionSessionDecodeFrame(
                     self.0,
                     sample_buffer.cf_type_ref() as _,

--- a/macos/video-toolbox/src/lib.rs
+++ b/macos/video-toolbox/src/lib.rs
@@ -13,5 +13,11 @@ pub mod sys {
     include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 }
 
+pub mod compression_session;
+pub use compression_session::*;
+
+pub mod video_encoder;
+pub use video_encoder::*;
+
 pub mod decompression_session;
 pub use decompression_session::*;

--- a/macos/video-toolbox/src/video_encoder.rs
+++ b/macos/video-toolbox/src/video_encoder.rs
@@ -1,0 +1,280 @@
+use super::*;
+use av_traits::{EncodedVideoFrame, RawVideoFrame, VideoEncoderOutput};
+use core_foundation::{Boolean, CFType, Dictionary, MutableDictionary, OSStatus};
+use core_media::{Time, VideoCodecType};
+use core_video::{PixelBuffer, PixelBufferPlane};
+use std::pin::Pin;
+
+#[derive(Clone, Copy, Debug)]
+pub enum VideoEncoderCodec {
+    H264,
+    H265,
+}
+
+impl From<VideoEncoderCodec> for VideoCodecType {
+    fn from(c: VideoEncoderCodec) -> Self {
+        match c {
+            VideoEncoderCodec::H264 => VideoCodecType::H264,
+            VideoEncoderCodec::H265 => VideoCodecType::Hevc,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct VideoEncoderConfig {
+    pub width: u16,
+    pub height: u16,
+    pub codec: VideoEncoderCodec,
+    pub input_format: VideoEncoderInputFormat,
+}
+
+#[derive(Clone, Debug)]
+pub enum VideoEncoderInputFormat {
+    Yuv420Planar,
+    Yuv444Planar,
+}
+
+/// `VideoEncoder` is a wrapper around `CompressionSession` that implements `av_traits::VideoEncoder`.
+pub struct VideoEncoder<F: Send> {
+    sess: CompressionSession<Pin<Box<F>>>,
+    config: VideoEncoderConfig,
+}
+
+impl<F: Send> VideoEncoder<F> {
+    pub fn new(config: VideoEncoderConfig) -> Result<Self, OSStatus> {
+        let mut encoder_specification = MutableDictionary::default();
+        unsafe {
+            encoder_specification.set_value(
+                sys::kVTVideoEncoderSpecification_EnableHardwareAcceleratedVideoEncoder as _,
+                Boolean::from(true).cf_type_ref() as _,
+            );
+            encoder_specification.set_value(
+                sys::kVTCompressionPropertyKey_AllowFrameReordering as _,
+                Boolean::from(false).cf_type_ref() as _,
+            );
+        }
+
+        Ok(Self {
+            sess: CompressionSession::new(CompressionSessionConfig {
+                width: config.width as _,
+                height: config.height as _,
+                codec_type: config.codec.into(),
+                encoder_specification: Some(encoder_specification.into()),
+            })?,
+            config,
+        })
+    }
+
+    fn next_video_encoder_trait_frame(&mut self) -> Result<Option<VideoEncoderOutput<F>>, OSStatus> {
+        Ok(match self.sess.frames().try_recv().ok().transpose()? {
+            Some(frame) => {
+                let mut is_keyframe = true;
+
+                unsafe {
+                    if let Some(attachments) = frame.sample_buffer.attachments_array() {
+                        if !attachments.is_empty() {
+                            if let Some(dict) = attachments.cf_type_value_at_index::<Dictionary>(0) {
+                                if let Some(not_sync) = dict.cf_type_value::<Boolean>(sys::kCMSampleAttachmentKey_NotSync as _) {
+                                    is_keyframe = !not_sync.value();
+                                }
+                            }
+                        }
+                    }
+                }
+
+                let data_buffer = frame.sample_buffer.data_buffer().expect("all frames should have data");
+                let data_buffer = data_buffer.create_contiguous(0, 0)?;
+                let mut avcc_data = data_buffer.data(0)?;
+
+                let format_desc = frame.sample_buffer.format_description().expect("all frames should have format descriptions");
+                let prefix_len = match self.config.codec {
+                    VideoEncoderCodec::H264 => format_desc.h264_parameter_set_at_index(0)?.nal_unit_header_length,
+                    VideoEncoderCodec::H265 => format_desc.hevc_parameter_set_at_index(0)?.nal_unit_header_length,
+                };
+
+                let mut data = Vec::with_capacity(avcc_data.len() + 100);
+
+                // if this is a keyframe, prepend parameter sets
+                if is_keyframe {
+                    match self.config.codec {
+                        VideoEncoderCodec::H264 => {
+                            for i in 0..2 {
+                                let ps = format_desc.h264_parameter_set_at_index(i)?;
+                                data.extend_from_slice(&[0, 0, 0, 1]);
+                                data.extend_from_slice(ps.data);
+                            }
+                        }
+                        VideoEncoderCodec::H265 => {
+                            for i in 0..3 {
+                                let ps = format_desc.hevc_parameter_set_at_index(i)?;
+                                data.extend_from_slice(&[0, 0, 0, 1]);
+                                data.extend_from_slice(ps.data);
+                            }
+                        }
+                    };
+                }
+
+                // convert from avcc to annex-b as we copy the data
+                while avcc_data.len() > prefix_len {
+                    let nalu_len = match prefix_len {
+                        1 => avcc_data[0] as usize,
+                        2 => (avcc_data[0] as usize) << 8 | avcc_data[1] as usize,
+                        3 => (avcc_data[0] as usize) << 16 | (avcc_data[1] as usize) << 8 | avcc_data[2] as usize,
+                        4 => (avcc_data[0] as usize) << 24 | (avcc_data[1] as usize) << 16 | (avcc_data[2] as usize) << 8 | avcc_data[3] as usize,
+                        l => panic!("invalid nalu length: {}", l),
+                    };
+                    let nalu = &avcc_data[prefix_len..prefix_len + nalu_len];
+                    data.extend_from_slice(&[0, 0, 0, 1]);
+                    data.extend_from_slice(nalu);
+                    avcc_data = &avcc_data[prefix_len + nalu_len..];
+                }
+
+                let encoded_frame = EncodedVideoFrame { data, is_keyframe };
+
+                let raw_frame = unsafe { *Pin::into_inner_unchecked(frame.context) };
+                Some(VideoEncoderOutput { encoded_frame, raw_frame })
+            }
+            None => None,
+        })
+    }
+}
+
+impl<F: RawVideoFrame<u8> + Send + Unpin> av_traits::VideoEncoder for VideoEncoder<F> {
+    type Error = OSStatus;
+    type RawVideoFrame = F;
+
+    fn encode(&mut self, input: Self::RawVideoFrame) -> Result<Option<VideoEncoderOutput<Self::RawVideoFrame>>, Self::Error> {
+        let input = Box::pin(input);
+        let pixel_buffer = unsafe {
+            PixelBuffer::with_planar_bytes(
+                self.config.width as _,
+                self.config.height as _,
+                match self.config.input_format {
+                    VideoEncoderInputFormat::Yuv420Planar => sys::kCVPixelFormatType_420YpCbCr8Planar,
+                    VideoEncoderInputFormat::Yuv444Planar => sys::kCVPixelFormatType_444YpCbCr8,
+                },
+                match self.config.input_format {
+                    VideoEncoderInputFormat::Yuv420Planar => vec![
+                        PixelBufferPlane {
+                            width: self.config.width as _,
+                            height: self.config.height as _,
+                            bytes_per_row: self.config.width as _,
+                            data: input.samples(0).as_ptr() as _,
+                        },
+                        PixelBufferPlane {
+                            width: (self.config.width / 2) as _,
+                            height: (self.config.height / 2) as _,
+                            bytes_per_row: (self.config.width / 2) as _,
+                            data: input.samples(1).as_ptr() as _,
+                        },
+                        PixelBufferPlane {
+                            width: (self.config.width / 2) as _,
+                            height: (self.config.height / 2) as _,
+                            bytes_per_row: (self.config.width / 2) as _,
+                            data: input.samples(2).as_ptr() as _,
+                        },
+                    ],
+                    VideoEncoderInputFormat::Yuv444Planar => vec![
+                        PixelBufferPlane {
+                            width: self.config.width as _,
+                            height: self.config.height as _,
+                            bytes_per_row: self.config.width as _,
+                            data: input.samples(0).as_ptr() as _,
+                        },
+                        PixelBufferPlane {
+                            width: self.config.width as _,
+                            height: self.config.height as _,
+                            bytes_per_row: self.config.width as _,
+                            data: input.samples(1).as_ptr() as _,
+                        },
+                        PixelBufferPlane {
+                            width: self.config.width as _,
+                            height: self.config.height as _,
+                            bytes_per_row: self.config.width as _,
+                            data: input.samples(2).as_ptr() as _,
+                        },
+                    ],
+                },
+            )?
+        };
+        self.sess.encode_frame(pixel_buffer.into(), Time::default(), input)?;
+        self.next_video_encoder_trait_frame()
+    }
+
+    fn flush(&mut self) -> Result<Option<VideoEncoderOutput<Self::RawVideoFrame>>, Self::Error> {
+        self.sess.flush()?;
+        self.next_video_encoder_trait_frame()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use av_traits::VideoEncoder as _;
+
+    struct TestFrame {
+        samples: Vec<Vec<u8>>,
+    }
+
+    impl RawVideoFrame<u8> for TestFrame {
+        fn samples(&self, plane: usize) -> &[u8] {
+            &self.samples[plane]
+        }
+    }
+
+    fn test_video_encoder(codec: VideoEncoderCodec) {
+        let mut encoder = VideoEncoder::new(VideoEncoderConfig {
+            width: 1920,
+            height: 1080,
+            codec,
+            input_format: VideoEncoderInputFormat::Yuv420Planar,
+        })
+        .unwrap();
+
+        let mut encoded = vec![];
+        let mut encoded_frames = 0;
+
+        let u = vec![200u8; 1920 * 1080 / 4];
+        let v = vec![128u8; 1920 * 1080 / 4];
+        for i in 0..90 {
+            let mut y = Vec::with_capacity(1920 * 1080);
+            for line in 0..1080 {
+                let sample = if line / 12 == i {
+                    // add some motion by drawing a line that moves from top to bottom
+                    16
+                } else {
+                    (16.0 + (line as f64 / 1080.0) * 219.0).round() as u8
+                };
+                y.resize(y.len() + 1920, sample);
+            }
+            let frame = TestFrame {
+                samples: vec![y, u.clone(), v.clone()],
+            };
+            if let Some(mut output) = encoder.encode(frame).unwrap() {
+                encoded.append(&mut output.encoded_frame.data);
+                encoded_frames += 1;
+            }
+        }
+        while let Some(mut output) = encoder.flush().unwrap() {
+            encoded.append(&mut output.encoded_frame.data);
+            encoded_frames += 1;
+        }
+
+        assert_eq!(encoded_frames, 90);
+        assert!(encoded.len() > 5000);
+
+        // To inspect the output, uncomment these lines:
+        //use std::io::Write;
+        //std::fs::File::create("tmp.bin").unwrap().write_all(&encoded).unwrap();
+    }
+
+    #[test]
+    fn test_video_encoder_h264() {
+        test_video_encoder(VideoEncoderCodec::H264);
+    }
+
+    #[test]
+    fn test_video_encoder_h265() {
+        test_video_encoder(VideoEncoderCodec::H265);
+    }
+}

--- a/x264/src/encoder.rs
+++ b/x264/src/encoder.rs
@@ -224,5 +224,9 @@ mod test {
 
         assert_eq!(encoded_frames, 90);
         assert!(encoded.len() > 5000);
+
+        // To inspect the output, uncomment these lines:
+        //use std::io::Write;
+        //std::fs::File::create("tmp.h264").unwrap().write_all(&encoded).unwrap();
     }
 }


### PR DESCRIPTION
Adds two new types to the video toolbox crate:

* An unopinionated abstraction over [VTCompressionSession](https://developer.apple.com/documentation/videotoolbox/vtcompressionsession?language=objc).
* An implementation of `av_traits::VideoEncoder`.

This enables encoding video as H264 or H265 using hardware acceleration on macOS.