### PR TITLE
added enumerations for aspect ratio to be used in av-service

### DIFF
--- a/xilinx/build.rs
+++ b/xilinx/build.rs
@@ -26,6 +26,7 @@ fn main() {
         println!("cargo:rustc-link-lib=dylib=xrt_core");
 
         let bindings = bindgen::Builder::default();
+        #[allow(deprecated)]
         let bindings = bindings
             .header("src/bindings.h")
             .clang_arg("-I/opt/xilinx/xrt/include/xma2")

--- a/xilinx/src/xlnx_enc_props.rs
+++ b/xilinx/src/xlnx_enc_props.rs
@@ -14,6 +14,13 @@ pub const ENC_H264_HIGH: i32 = 100;
 pub const ENC_HEVC_MAIN: i32 = 0;
 pub const ENC_HEVC_MAIN_INTRA: i32 = 1;
 
+pub enum XlnxAspectRatio {
+    AspectRatio4x3,
+    AspectRatio16x9,
+    AspectRatioNone,
+    AspectRatioAuto,
+}
+
 pub const CODEC_ID_HEVC: i32 = 1;
 pub const CODEC_ID_H264: i32 = 0;
 
@@ -47,7 +54,7 @@ pub struct XlnxEncoderProperties {
     pub spatial_aq_gain: i32,
     pub qp_mode: i32,
     pub filler_data: bool,
-    pub aspect_ratio: i32,
+    pub aspect_ratio: XlnxAspectRatio,
     pub scaling_list: i32,
     pub entropy_mode: i32,
     pub loop_filter: bool,
@@ -192,10 +199,10 @@ pub fn xlnx_create_xma_enc_props(
     let filler_data = if enc_props.filler_data { "ENABLE" } else { "DISABLE" };
 
     let aspect_ratio = match enc_props.aspect_ratio {
-        1 => "ASPECT_RATIO_4_3",
-        2 => "ASPECT_RATIO_16_9",
-        3 => "ASPECT_RATIO_NONE",
-        _ => "ASPECT_RATIO_AUTO",
+        XlnxAspectRatio::AspectRatio4x3 => "ASPECT_RATIO_4_3",
+        XlnxAspectRatio::AspectRatio16x9 => "ASPECT_RATIO_16_9",
+        XlnxAspectRatio::AspectRatioNone => "ASPECT_RATIO_NONE",
+        XlnxAspectRatio::AspectRatioAuto => "ASPECT_RATIO_AUTO",
     };
 
     let color_space = "COLOUR_DESC_UNSPECIFIED";

--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -139,7 +139,7 @@ mod encoder_tests {
             spatial_aq_gain: 50,
             qp_mode: 1,
             filler_data: false,
-            aspect_ratio: 2,
+            aspect_ratio: XlnxAspectRatio::AspectRatio16x9,
             scaling_list: 1,
             entropy_mode: 1,
             loop_filter: true,


### PR DESCRIPTION
Adds enumerations for aspect ratio encoder property for readability. Also suppresses bindgen deprecated build warnings

