### PR TITLE
make encoder out_buffer public

### DIFF
--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -3,7 +3,7 @@ use simple_error::SimpleError;
 
 pub struct XlnxEncoder {
     enc_session: *mut XmaEncoderSession,
-    out_buffer: *mut XmaDataBuffer,
+    pub out_buffer: *mut XmaDataBuffer,
     flush_frame_sent: bool,
 }
 


### PR DESCRIPTION
The xilinx encoder's output buffer was not public and therefore not accessible to be read by any other services. This has been rectified.