### PR TITLE
fix srt build.rs when cross-compiling

### DIFF
--- a/srt/build.rs
+++ b/srt/build.rs
@@ -1,19 +1,21 @@
+use std::env::var;
+
 fn main() {
-    #[cfg(target_os = "macos")]
-    {
-        #[cfg(target_arch = "x86_64")]
-        println!("cargo:rustc-link-search={}/vendor/macos-x86_64/lib", env!("CARGO_MANIFEST_DIR"));
-        #[cfg(target_arch = "aarch64")]
-        println!("cargo:rustc-link-search={}/vendor/macos-aarch64/lib", env!("CARGO_MANIFEST_DIR"));
-
-        println!("cargo:rustc-link-lib=c++");
-    }
-
-    #[cfg(target_os = "linux")]
-    {
-        println!("cargo:rustc-link-search={}/vendor/linux/lib", env!("CARGO_MANIFEST_DIR"));
-        println!("cargo:rustc-link-lib=c");
-        println!("cargo:rustc-link-lib=stdc++");
-        println!("cargo:rustc-link-lib=crypto");
+    match var("CARGO_CFG_TARGET_OS").expect("CARGO_CFG_TARGET_OS must be set").as_str() {
+        "macos" => {
+            match var("CARGO_CFG_TARGET_ARCH").expect("CARGO_CFG_TARGET_ARCH must be set").as_str() {
+                "x86_64" => println!("cargo:rustc-link-search={}/vendor/macos-x86_64/lib", env!("CARGO_MANIFEST_DIR")),
+                "aarch64" => println!("cargo:rustc-link-search={}/vendor/macos-aarch64/lib", env!("CARGO_MANIFEST_DIR")),
+                _ => {}
+            }
+            println!("cargo:rustc-link-lib=c++");
+        }
+        "linux" => {
+            println!("cargo:rustc-link-search={}/vendor/linux/lib", env!("CARGO_MANIFEST_DIR"));
+            println!("cargo:rustc-link-lib=c");
+            println!("cargo:rustc-link-lib=stdc++");
+            println!("cargo:rustc-link-lib=crypto");
+        }
+        _ => {}
     }
 }


### PR DESCRIPTION
Attributes like `#[cfg(target_os = "linux")]` are for conditional compilation, and the build script is always compiled for the host machine. Thus these weren't having the intended effect when cross-compiling.

To cross-compile correctly, the `CARGO_` environment variables should be checked by the build script at runtime.