### PR TITLE
Init now query devices. Made some fields pubic

### DIFF
--- a/xilinx/build.rs
+++ b/xilinx/build.rs
@@ -36,6 +36,7 @@ fn main() {
             .whitelist_function("xrm.*")
             .whitelist_function("xvbm.*")
             .whitelist_function("xma_.*")
+            .whitelist_function("xclProbe.*")
             .whitelist_type("xma.*")
             .whitelist_type("xvbm.*")
             .whitelist_type("xrm.*")

--- a/xilinx/src/bindings.h
+++ b/xilinx/src/bindings.h
@@ -2,3 +2,4 @@
 #include <xmaplugin.h>
 #include <xma.h>
 #include <xvbm.h>
+#include <xrt.h>

--- a/xilinx/src/lib.rs
+++ b/xilinx/src/lib.rs
@@ -37,12 +37,11 @@ pub use xlnx_error::*;
 
 const XCLBIN_FILENAME: &[u8] = b"/opt/xilinx/xcdr/xclbins/transcode.xclbin\0";
 
-/// initalized the number of devices specified with the default xclbin_name
+/// initalizes all devices on system with the default xclbin_name
 ///
-/// @decice_count: The number of devices available in the system.
-pub fn xlnx_init_all_devices(device_count: i32) -> Result<(), simple_error::SimpleError> {
+pub fn xlnx_init_all_devices() -> Result<i32, simple_error::SimpleError> {
     let mut xclbin_params = Vec::new();
-
+    let device_count =  unsafe { xclProbe() } as i32;
     for i in 0..device_count {
         xclbin_params.push(XmaXclbinParameter {
             xclbin_name: XCLBIN_FILENAME.as_ptr() as *mut i8,
@@ -55,7 +54,7 @@ pub fn xlnx_init_all_devices(device_count: i32) -> Result<(), simple_error::Simp
         simple_error::bail!("xma initalization failed")
     }
 
-    Ok(())
+    Ok(device_count)
 }
 
 pub(crate) fn xrm_precision_1000000_bitmask(val: i32) -> i32 {
@@ -87,7 +86,7 @@ pub mod tests {
 
     pub fn initialize() {
         INIT.call_once(|| {
-            xlnx_init_all_devices(2).unwrap();
+            xlnx_init_all_devices().unwrap();
         });
     }
 

--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -4,7 +4,7 @@ use simple_error::SimpleError;
 pub struct XlnxEncoder {
     enc_session: *mut XmaEncoderSession,
     pub out_buffer: *mut XmaDataBuffer,
-    flush_frame_sent: bool,
+    pub flush_frame_sent: bool,
 }
 
 impl XlnxEncoder {
@@ -236,7 +236,7 @@ mod encoder_tests {
 
         processed_frame_count
     }
-
+    
     #[test]
     fn test_hevc_encode() {
         let processed_frame_count = encode_raw(CODEC_ID_HEVC, ENC_HEVC_MAIN, 31);

--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -236,7 +236,6 @@ mod encoder_tests {
 
         processed_frame_count
     }
-    
     #[test]
     fn test_hevc_encode() {
         let processed_frame_count = encode_raw(CODEC_ID_HEVC, ENC_HEVC_MAIN, 31);

--- a/xilinx/src/xlnx_scal_props.rs
+++ b/xilinx/src/xlnx_scal_props.rs
@@ -2,7 +2,7 @@ use crate::{strcpy_to_arr_i8, sys::*, xlnx_scaler::SCAL_MAX_ABR_CHANNELS};
 use simple_error::SimpleError;
 use std::ptr;
 
-pub(crate) const MAX_SCAL_PARAMS: usize = 4;
+pub const MAX_SCAL_PARAMS: usize = 4;
 const ENABLE_PIPELINE_PARAM_NAME: &[u8] = b"enable_pipeline\0";
 const LOG_LEVEL_PARAM_NAME: &[u8] = b"logLevel\0";
 const MIX_RATE_PARAM_NAME: &[u8] = b"MixRate\0";
@@ -12,8 +12,7 @@ const TRANSCODE_WIDTH_ALIGN: i32 = 256;
 pub struct XlnxScalerProperties {
     pub in_width: i32,
     pub in_height: i32,
-    pub fr_num: i32,
-    pub fr_den: i32,
+    pub framerate: XmaFraction,
     pub nb_outputs: i32,
     pub out_width: [i32; SCAL_MAX_ABR_CHANNELS],
     pub out_height: [i32; SCAL_MAX_ABR_CHANNELS],
@@ -62,8 +61,8 @@ pub fn xlnx_create_xma_scal_props(
     xma_scal_props.input.width = scal_props.in_width;
     xma_scal_props.input.height = scal_props.in_height;
     xma_scal_props.input.stride = align(scal_props.in_width, TRANSCODE_WIDTH_ALIGN);
-    xma_scal_props.input.framerate.numerator = scal_props.fr_num;
-    xma_scal_props.input.framerate.denominator = scal_props.fr_den;
+    xma_scal_props.input.framerate.numerator = scal_props.framerate.numerator;
+    xma_scal_props.input.framerate.denominator = scal_props.framerate.denominator;
 
     for i in 0..scal_props.nb_outputs as usize {
         xma_scal_props.output[i].format = XmaFormatType_XMA_VCU_NV12_FMT_TYPE;
@@ -72,8 +71,8 @@ pub fn xlnx_create_xma_scal_props(
         xma_scal_props.output[i].height = scal_props.out_height[i];
         xma_scal_props.output[i].stride = align(scal_props.out_width[i], TRANSCODE_WIDTH_ALIGN);
         xma_scal_props.output[i].coeffLoad = 0;
-        xma_scal_props.output[i].framerate.numerator = scal_props.fr_num;
-        xma_scal_props.output[i].framerate.denominator = scal_props.fr_den;
+        xma_scal_props.output[i].framerate.numerator = scal_props.framerate.numerator;
+        xma_scal_props.output[i].framerate.denominator = scal_props.framerate.denominator;
     }
 
     xlnx_fill_scal_params(scal_props, scal_params);

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -132,8 +132,7 @@ mod scaler_tests {
         let mut scal_props = Box::new(XlnxScalerProperties {
             in_width: 1280,
             in_height: 720,
-            fr_num: 1,
-            fr_den: 25,
+            framerate: XmaFraction { numerator: 1, denominator: 25 },
             nb_outputs: 3,
             out_width: [1280, 852, 640, 0, 0, 0, 0, 0],
             out_height: [720, 480, 360, 0, 0, 0, 0, 0],


### PR DESCRIPTION
What it does: the initialize function now queries the number of devices instead of taking a number as a parameter. This allows us to attempt to initialize and query if there are devices on the system or not.

There were also some fields that needed to be changed (made public and changing types)