### PR TITLE
add bitrate parameters for x264 and video toolbox encoders

### DIFF
--- a/macos/core-foundation/build.rs
+++ b/macos/core-foundation/build.rs
@@ -17,6 +17,7 @@ fn main() {
             .whitelist_function("CF.+")
             .whitelist_var("kCFString.+")
             .whitelist_var("kCFBoolean.+")
+            .whitelist_var("kCFNumber.+")
             .whitelist_type("CFStringBuiltInEncodings")
             .whitelist_type("OSStatus")
             .prepend_enum_name(false)

--- a/macos/core-foundation/build.rs
+++ b/macos/core-foundation/build.rs
@@ -17,6 +17,7 @@ fn main() {
             .whitelist_function("CF.+")
             .whitelist_var("kCFString.+")
             .whitelist_var("kCFBoolean.+")
+            .whitelist_var("kCFTypeDictionary.+")
             .whitelist_var("kCFNumber.+")
             .whitelist_type("CFStringBuiltInEncodings")
             .whitelist_type("OSStatus")

--- a/macos/core-foundation/src/dictionary.rs
+++ b/macos/core-foundation/src/dictionary.rs
@@ -20,20 +20,20 @@ impl Dictionary {
 pub struct MutableDictionary(sys::CFMutableDictionaryRef);
 crate::trait_impls!(MutableDictionary);
 
-impl Default for MutableDictionary {
-    fn default() -> Self {
-        Self::with_capacity(0)
-    }
-}
-
 impl MutableDictionary {
-    pub fn with_capacity(capacity: usize) -> Self {
+    /// Creates a new mutable dictionary which will only contain CFType objects.
+    pub fn new_cf_type() -> Self {
+        Self::cf_type_with_capacity(0)
+    }
+
+    /// Creates a new mutable dictionary which will only contain CFType objects and has the given capacity.
+    pub fn cf_type_with_capacity(capacity: usize) -> Self {
         unsafe {
             Self(sys::CFDictionaryCreateMutable(
                 std::ptr::null_mut(),
                 capacity as _,
-                std::ptr::null_mut(),
-                std::ptr::null_mut(),
+                &sys::kCFTypeDictionaryKeyCallBacks as _,
+                &sys::kCFTypeDictionaryValueCallBacks as _,
             ))
         }
     }

--- a/macos/core-foundation/src/dictionary.rs
+++ b/macos/core-foundation/src/dictionary.rs
@@ -57,7 +57,7 @@ mod test {
 
     #[test]
     fn test_dictionary() {
-        let mut d = MutableDictionary::default();
+        let mut d = MutableDictionary::new_cf_type();
 
         unsafe {
             let key = sys::kCFStringTransformToLatin;

--- a/macos/core-foundation/src/lib.rs
+++ b/macos/core-foundation/src/lib.rs
@@ -24,6 +24,9 @@ pub use boolean::*;
 pub mod dictionary;
 pub use dictionary::*;
 
+pub mod number;
+pub use number::*;
+
 #[macro_export]
 macro_rules! trait_impls {
     ($e:ident) => {

--- a/macos/core-foundation/src/number.rs
+++ b/macos/core-foundation/src/number.rs
@@ -45,11 +45,11 @@ mod test {
 
     #[test]
     fn test_number() {
-        let _ = Number::from(1 as i8);
-        let _ = Number::from(1 as i16);
-        let _ = Number::from(1 as i32);
-        let _ = Number::from(1 as i64);
-        let _ = Number::from(1 as f32);
-        let _ = Number::from(1 as f64);
+        let _ = Number::from(1_i8);
+        let _ = Number::from(1_i16);
+        let _ = Number::from(1_i32);
+        let _ = Number::from(1_i64);
+        let _ = Number::from(1_f32);
+        let _ = Number::from(1_f64);
     }
 }

--- a/macos/core-foundation/src/number.rs
+++ b/macos/core-foundation/src/number.rs
@@ -1,0 +1,55 @@
+use super::*;
+
+pub struct Number(sys::CFNumberRef);
+crate::trait_impls!(Number);
+
+impl From<i8> for Number {
+    fn from(n: i8) -> Self {
+        unsafe { Self(sys::CFNumberCreate(std::ptr::null_mut(), sys::kCFNumberSInt8Type as _, &n as *const i8 as _)) }
+    }
+}
+
+impl From<i16> for Number {
+    fn from(n: i16) -> Self {
+        unsafe { Self(sys::CFNumberCreate(std::ptr::null_mut(), sys::kCFNumberSInt16Type as _, &n as *const i16 as _)) }
+    }
+}
+
+impl From<i32> for Number {
+    fn from(n: i32) -> Self {
+        unsafe { Self(sys::CFNumberCreate(std::ptr::null_mut(), sys::kCFNumberSInt32Type as _, &n as *const i32 as _)) }
+    }
+}
+
+impl From<i64> for Number {
+    fn from(n: i64) -> Self {
+        unsafe { Self(sys::CFNumberCreate(std::ptr::null_mut(), sys::kCFNumberSInt64Type as _, &n as *const i64 as _)) }
+    }
+}
+
+impl From<f32> for Number {
+    fn from(n: f32) -> Self {
+        unsafe { Self(sys::CFNumberCreate(std::ptr::null_mut(), sys::kCFNumberFloat32Type as _, &n as *const f32 as _)) }
+    }
+}
+
+impl From<f64> for Number {
+    fn from(n: f64) -> Self {
+        unsafe { Self(sys::CFNumberCreate(std::ptr::null_mut(), sys::kCFNumberFloat64Type as _, &n as *const f64 as _)) }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_number() {
+        let _ = Number::from(1 as i8);
+        let _ = Number::from(1 as i16);
+        let _ = Number::from(1 as i32);
+        let _ = Number::from(1 as i64);
+        let _ = Number::from(1 as f32);
+        let _ = Number::from(1 as f64);
+    }
+}

--- a/macos/core-media/src/time.rs
+++ b/macos/core-media/src/time.rs
@@ -18,3 +18,13 @@ impl From<Time> for sys::CMTime {
         }
     }
 }
+
+impl Time {
+    pub fn new(value: i64, timescale: i32) -> Self {
+        Self {
+            value,
+            timescale,
+            ..Default::default()
+        }
+    }
+}

--- a/macos/video-toolbox/src/video_encoder.rs
+++ b/macos/video-toolbox/src/video_encoder.rs
@@ -44,7 +44,7 @@ pub struct VideoEncoder<F: Send> {
 
 impl<F: Send> VideoEncoder<F> {
     pub fn new(config: VideoEncoderConfig) -> Result<Self, OSStatus> {
-        let mut encoder_specification = MutableDictionary::default();
+        let mut encoder_specification = MutableDictionary::new_cf_type();
         unsafe {
             encoder_specification.set_value(
                 sys::kVTVideoEncoderSpecification_EnableHardwareAcceleratedVideoEncoder as _,

--- a/macos/video-toolbox/src/video_encoder.rs
+++ b/macos/video-toolbox/src/video_encoder.rs
@@ -1,21 +1,21 @@
 use super::*;
 use av_traits::{EncodedVideoFrame, RawVideoFrame, VideoEncoderOutput};
-use core_foundation::{Boolean, CFType, Dictionary, MutableDictionary, OSStatus};
+use core_foundation::{Boolean, CFType, Dictionary, MutableDictionary, Number, OSStatus};
 use core_media::{Time, VideoCodecType};
 use core_video::{PixelBuffer, PixelBufferPlane};
 use std::pin::Pin;
 
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Debug)]
 pub enum VideoEncoderCodec {
-    H264,
-    H265,
+    H264 { bitrate: Option<u32> },
+    H265 { bitrate: Option<u32> },
 }
 
-impl From<VideoEncoderCodec> for VideoCodecType {
-    fn from(c: VideoEncoderCodec) -> Self {
+impl From<&VideoEncoderCodec> for VideoCodecType {
+    fn from(c: &VideoEncoderCodec) -> Self {
         match c {
-            VideoEncoderCodec::H264 => VideoCodecType::H264,
-            VideoEncoderCodec::H265 => VideoCodecType::Hevc,
+            VideoEncoderCodec::H264 { .. } => VideoCodecType::H264,
+            VideoEncoderCodec::H265 { .. } => VideoCodecType::Hevc,
         }
     }
 }
@@ -24,6 +24,7 @@ impl From<VideoEncoderCodec> for VideoCodecType {
 pub struct VideoEncoderConfig {
     pub width: u16,
     pub height: u16,
+    pub fps: f64,
     pub codec: VideoEncoderCodec,
     pub input_format: VideoEncoderInputFormat,
 }
@@ -38,6 +39,7 @@ pub enum VideoEncoderInputFormat {
 pub struct VideoEncoder<F: Send> {
     sess: CompressionSession<Pin<Box<F>>>,
     config: VideoEncoderConfig,
+    frame_count: u64,
 }
 
 impl<F: Send> VideoEncoder<F> {
@@ -52,16 +54,45 @@ impl<F: Send> VideoEncoder<F> {
                 sys::kVTCompressionPropertyKey_AllowFrameReordering as _,
                 Boolean::from(false).cf_type_ref() as _,
             );
+            encoder_specification.set_value(sys::kVTCompressionPropertyKey_RealTime as _, Boolean::from(true).cf_type_ref() as _);
+            encoder_specification.set_value(
+                sys::kVTCompressionPropertyKey_ExpectedFrameRate as _,
+                Number::from(config.fps).cf_type_ref() as _,
+            );
+        }
+
+        match &config.codec {
+            VideoEncoderCodec::H264 { bitrate } => {
+                if let Some(bitrate) = bitrate {
+                    unsafe {
+                        encoder_specification.set_value(
+                            sys::kVTCompressionPropertyKey_AverageBitRate as _,
+                            Number::from(*bitrate as i64).cf_type_ref() as _,
+                        );
+                    }
+                }
+            }
+            VideoEncoderCodec::H265 { bitrate } => {
+                if let Some(bitrate) = bitrate {
+                    unsafe {
+                        encoder_specification.set_value(
+                            sys::kVTCompressionPropertyKey_AverageBitRate as _,
+                            Number::from(*bitrate as i64).cf_type_ref() as _,
+                        );
+                    }
+                }
+            }
         }
 
         Ok(Self {
             sess: CompressionSession::new(CompressionSessionConfig {
                 width: config.width as _,
                 height: config.height as _,
-                codec_type: config.codec.into(),
+                codec_type: (&config.codec).into(),
                 encoder_specification: Some(encoder_specification.into()),
             })?,
             config,
+            frame_count: 0,
         })
     }
 
@@ -88,8 +119,8 @@ impl<F: Send> VideoEncoder<F> {
 
                 let format_desc = frame.sample_buffer.format_description().expect("all frames should have format descriptions");
                 let prefix_len = match self.config.codec {
-                    VideoEncoderCodec::H264 => format_desc.h264_parameter_set_at_index(0)?.nal_unit_header_length,
-                    VideoEncoderCodec::H265 => format_desc.hevc_parameter_set_at_index(0)?.nal_unit_header_length,
+                    VideoEncoderCodec::H264 { .. } => format_desc.h264_parameter_set_at_index(0)?.nal_unit_header_length,
+                    VideoEncoderCodec::H265 { .. } => format_desc.hevc_parameter_set_at_index(0)?.nal_unit_header_length,
                 };
 
                 let mut data = Vec::with_capacity(avcc_data.len() + 100);
@@ -97,14 +128,14 @@ impl<F: Send> VideoEncoder<F> {
                 // if this is a keyframe, prepend parameter sets
                 if is_keyframe {
                     match self.config.codec {
-                        VideoEncoderCodec::H264 => {
+                        VideoEncoderCodec::H264 { .. } => {
                             for i in 0..2 {
                                 let ps = format_desc.h264_parameter_set_at_index(i)?;
                                 data.extend_from_slice(&[0, 0, 0, 1]);
                                 data.extend_from_slice(ps.data);
                             }
                         }
-                        VideoEncoderCodec::H265 => {
+                        VideoEncoderCodec::H265 { .. } => {
                             for i in 0..3 {
                                 let ps = format_desc.hevc_parameter_set_at_index(i)?;
                                 data.extend_from_slice(&[0, 0, 0, 1]);
@@ -197,7 +228,14 @@ impl<F: RawVideoFrame<u8> + Send + Unpin> av_traits::VideoEncoder for VideoEncod
                 },
             )?
         };
-        self.sess.encode_frame(pixel_buffer.into(), Time::default(), input)?;
+
+        let fps_den = if self.config.fps.fract() == 0.0 { 1000 } else { 1001 };
+        let fps_num = (self.config.fps * fps_den as f64).round() as i64;
+
+        let frame_number = self.frame_count;
+        self.frame_count += 1;
+        self.sess
+            .encode_frame(pixel_buffer.into(), Time::new((fps_den * frame_number) as _, fps_num as _), input)?;
         self.next_video_encoder_trait_frame()
     }
 
@@ -226,6 +264,7 @@ mod test {
         let mut encoder = VideoEncoder::new(VideoEncoderConfig {
             width: 1920,
             height: 1080,
+            fps: 29.97,
             codec,
             input_format: VideoEncoderInputFormat::Yuv420Planar,
         })
@@ -270,11 +309,11 @@ mod test {
 
     #[test]
     fn test_video_encoder_h264() {
-        test_video_encoder(VideoEncoderCodec::H264);
+        test_video_encoder(VideoEncoderCodec::H264 { bitrate: Some(10000) });
     }
 
     #[test]
     fn test_video_encoder_h265() {
-        test_video_encoder(VideoEncoderCodec::H265);
+        test_video_encoder(VideoEncoderCodec::H265 { bitrate: Some(10000) });
     }
 }


### PR DESCRIPTION
Before, I just let libx264 and Video Toolbox use whatever bitrate they wanted. Now, users can optionally specify a target bitrate.