### PR TITLE
static x264 linkage

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,6 +13,7 @@ jobs:
     - name: Set Up Linux
       if: startsWith(matrix.os, 'ubuntu-')
       run: |
+        sudo apt-get update && sudo apt-get install -y nasm
         git clone https://github.com/mirror/x264.git x264-mirror
         (cd x264-mirror && git checkout 5db6aa6cab1b146e07b60cc1736a01f21da01154 && ./configure --disable-cli --enable-static && make -j && sudo make install)
         git clone https://github.com/ultravideo/kvazaar.git

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,8 @@ jobs:
     - name: Set Up Linux
       if: startsWith(matrix.os, 'ubuntu-')
       run: |
-        sudo apt-get update && sudo apt-get install -y libx264-dev
+        git clone https://github.com/mirror/x264.git
+        (cd x264 && git checkout 5db6aa6cab1b146e07b60cc1736a01f21da01154 && ./configure --disable-cli --enable-static && make -j && sudo make install)
         git clone https://github.com/ultravideo/kvazaar.git
         (cd kvazaar && git checkout 8143ab971cbbdd78a3ac12cf7904209e1db659c6 && ./autogen.sh && ./configure && make -j && sudo make install)
     - name: Set Up macOS

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,8 +13,8 @@ jobs:
     - name: Set Up Linux
       if: startsWith(matrix.os, 'ubuntu-')
       run: |
-        git clone https://github.com/mirror/x264.git
-        (cd x264 && git checkout 5db6aa6cab1b146e07b60cc1736a01f21da01154 && ./configure --disable-cli --enable-static && make -j && sudo make install)
+        git clone https://github.com/mirror/x264.git x264-mirror
+        (cd x264-mirror && git checkout 5db6aa6cab1b146e07b60cc1736a01f21da01154 && ./configure --disable-cli --enable-static && make -j && sudo make install)
         git clone https://github.com/ultravideo/kvazaar.git
         (cd kvazaar && git checkout 8143ab971cbbdd78a3ac12cf7904209e1db659c6 && ./autogen.sh && ./configure && make -j && sudo make install)
     - name: Set Up macOS

--- a/x264/x264-sys/Cargo.toml
+++ b/x264/x264-sys/Cargo.toml
@@ -8,3 +8,4 @@ build = "build.rs"
 # We're very permissive here with bindgen due to https://github.com/rust-lang/cargo/issues/5237
 bindgen = "0.*"
 cc = "1.0"
+pkg-config = "0.3.25"

--- a/x264/x264-sys/build.rs
+++ b/x264/x264-sys/build.rs
@@ -4,7 +4,13 @@ use std::env;
 use std::path::PathBuf;
 
 fn main() {
-    println!("cargo:rustc-link-lib=x264");
+    if let Ok(info) = pkg_config::probe_library("x264") {
+        for path in info.link_paths {
+            println!("cargo:rustc-link-search={}", path.display());
+        }
+    }
+
+    println!("cargo:rustc-link-lib=static=x264");
 
     cc::Build::new().file("src/lib.c").compile("x264-sys");
 


### PR DESCRIPTION
Links x264 statically to produce more portable binaries.

`ldd` before:

```
	linux-vdso.so.1 (0x00007ffc623fe000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f73a89f6000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f73a9302000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f73a8814000)
	libx264.so.155 => /lib/x86_64-linux-gnu/libx264.so.155 (0x00007f73a8556000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f73a853b000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f73a8530000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f73a850b000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f73a83bc000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f73a83b6000)
```

And after (libx264 is no longer a runtime dependency):

```
	linux-vdso.so.1 (0x00007ffe7fbe8000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f20d0976000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f20d15aa000)
	libstdc++.so.6 => /lib/x86_64-linux-gnu/libstdc++.so.6 (0x00007f20d0794000)
	libgcc_s.so.1 => /lib/x86_64-linux-gnu/libgcc_s.so.1 (0x00007f20d0779000)
	librt.so.1 => /lib/x86_64-linux-gnu/librt.so.1 (0x00007f20d076e000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f20d074b000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f20d05fa000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f20d05f4000)
```

This required updating to a newer version of x264.