### PR TITLE
fix video toolbox compression session properties

### DIFF
--- a/macos/video-toolbox/build.rs
+++ b/macos/video-toolbox/build.rs
@@ -16,6 +16,7 @@ fn main() {
             .header("src/lib.hpp")
             .whitelist_function("VTCompressionSession.+")
             .whitelist_function("VTDecompressionSession.+")
+            .whitelist_function("VTSessionSetProperty")
             .whitelist_var("kCMTime.+")
             .whitelist_var("kCVPixelFormatType_.+")
             .whitelist_var("kCMSampleAttachmentKey_.+")

--- a/macos/video-toolbox/src/compression_session.rs
+++ b/macos/video-toolbox/src/compression_session.rs
@@ -90,6 +90,14 @@ impl<C: Send> CompressionSession<C> {
         })
     }
 
+    pub fn set_property<V: CFType>(&mut self, key: sys::CFStringRef, value: V) -> Result<(), OSStatus> {
+        unsafe { result(sys::VTSessionSetProperty(self.sess as _, key as _, value.cf_type_ref()).into()) }
+    }
+
+    pub fn prepare_to_encode_frames(&mut self) -> Result<(), OSStatus> {
+        unsafe { result(sys::VTCompressionSessionPrepareToEncodeFrames(self.sess).into()) }
+    }
+
     pub fn frames(&self) -> &mpsc::Receiver<Result<CompressionSessionOutputFrame<C>, OSStatus>> {
         &self.frames
     }


### PR DESCRIPTION
Previously all of these properties were added to the encoder configuration. But there's actually a function specifically for setting the properties with the "kVTCompressionPropertyKey" prefix. This uses it, which makes them actually do what they should do.

Unfortunately these are all things that are pretty hard to test for as VideoToolbox silently ignored this mistake and the properties more or less only impact performance characteristics.