### PR TITLE
use VecDeque and Duration from core crate

### DIFF
--- a/mpeg2/src/interleaving_muxer.rs
+++ b/mpeg2/src/interleaving_muxer.rs
@@ -1,9 +1,9 @@
 use super::EncodeError;
 use crate::muxer::{Muxer, Packet, Stream, StreamConfig};
+use alloc::collections::vec_deque::VecDeque;
 use alloc::vec::Vec;
+use core::time::Duration;
 use core2::io::Write;
-use std::collections::VecDeque;
-use std::time::Duration;
 
 const TS_33BIT_MASK: u64 = 0x1FFFFFFFF;
 


### PR DESCRIPTION
`InterleavingMuxer` is using std-crate structs `VecDeque` and `Duration` , should be made no_std instead.

```rust
use alloc::collections::vec_deque::VecDeque;
use core::time::Duration;
```