### PR TITLE
explicitly set architecture for macos srt cmake build

### DIFF
--- a/srt/srt-sys/build.rs
+++ b/srt/srt-sys/build.rs
@@ -6,6 +6,13 @@ fn main() {
     build.define("ENABLE_APPS", "OFF").define("ENABLE_SHARED", "OFF");
 
     if target_os == "macos" {
+        build.define(
+            "CMAKE_OSX_ARCHITECTURES",
+            match target_arch.as_str() {
+                "aarch64" => "arm64",
+                arch => arch,
+            },
+        );
         build.define("OPENSSL_INCLUDE_DIR", format!("{}/vendor/openssl/include", env!("CARGO_MANIFEST_DIR")));
         build.define(
             "OPENSSL_CRYPTO_LIBRARY",


### PR DESCRIPTION
After https://github.com/sportsball-ai/av-rs/pull/79, it seems like cmake wasn't doing the right thing by default when cross-compiling for x86_64 on macOS. It appeared to be creating a universal binary, which was not intended and triggers issues related to https://github.com/rust-lang/rust/issues/55235.

After specifying `CMAKE_OSX_ARCHITECTURES` explicitly, cmake creates thin binaries and downstream applications can link successfully.