### PR TITLE
[AVS-288] Update the video encoder abstraction 

### DIFF
--- a/av-traits/src/video_encoder.rs
+++ b/av-traits/src/video_encoder.rs
@@ -19,7 +19,6 @@ pub struct VideoEncoderOutput<F> {
 pub enum EncodedFrameType {
     Auto,
     Key,
-    Predicted,
 }
 
 /// Implements basic video encoding behavior.

--- a/av-traits/src/video_encoder.rs
+++ b/av-traits/src/video_encoder.rs
@@ -27,13 +27,13 @@ pub enum EncodedFrameType {
 /// Typical usage should look like this:
 ///
 /// ```
-/// # use av_traits::{RawVideoFrame, VideoEncoder};
+/// # use av_traits::{EncodedFrameType, RawVideoFrame, VideoEncoder};
 /// fn encode<S, E>(mut source: S, mut encoder: E) -> Result<(), E::Error>
 ///     where S: Iterator<Item = Box<dyn RawVideoFrame<u8>>>,
 ///     E: VideoEncoder<RawVideoFrame = Box<dyn RawVideoFrame<u8>>>
 /// {
 ///     while let Some(frame) = source.next() {
-///         if let Some(output) = encoder.encode(frame)? {
+///         if let Some(output) = encoder.encode(frame, EncodedFrameType::Auto)? {
 ///             // do something with output  
 ///         }
 ///     }

--- a/av-traits/src/video_encoder.rs
+++ b/av-traits/src/video_encoder.rs
@@ -16,6 +16,12 @@ pub struct VideoEncoderOutput<F> {
     pub encoded_frame: EncodedVideoFrame,
 }
 
+pub enum EncodedFrameType {
+    Auto,
+    Key,
+    Predicted,
+}
+
 /// Implements basic video encoding behavior.
 ///
 /// Typical usage should look like this:
@@ -50,7 +56,7 @@ pub trait VideoEncoder {
     ///
     /// Because output may be delayed, the returned frame is not necessarily the same as the input
     /// frame.
-    fn encode(&mut self, frame: Self::RawVideoFrame) -> Result<Option<VideoEncoderOutput<Self::RawVideoFrame>>, Self::Error>;
+    fn encode(&mut self, frame: Self::RawVideoFrame, frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<Self::RawVideoFrame>>, Self::Error>;
 
     /// Indicates to the encoder that no more input will be provided and it should emit any delayed
     /// frames. This should be invoked until no more frames are returned.

--- a/macos/video-toolbox/build.rs
+++ b/macos/video-toolbox/build.rs
@@ -8,7 +8,7 @@ fn main() {
 
         let sdk_root = "/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk";
 
-        // the "whilelist_" functions have been renamed in newer bindgen versions, but we use the
+        // the "whitelist_" functions have been renamed in newer bindgen versions, but we use the
         // old names for wider compatibility
         #[allow(deprecated)]
         let bindings = bindgen::Builder::default()
@@ -22,6 +22,7 @@ fn main() {
             .whitelist_var("kCMSampleAttachmentKey_.+")
             .whitelist_var("kVTVideoEncoderSpecification_.+")
             .whitelist_var("kVTCompressionPropertyKey_.+")
+            .whitelist_var("kVTEncodeFrameOptionKey_.+")
             .generate()
             .expect("unable to generate bindings");
 

--- a/macos/video-toolbox/src/compression_session.rs
+++ b/macos/video-toolbox/src/compression_session.rs
@@ -112,7 +112,7 @@ impl<C: Send> CompressionSession<C> {
                     EncodedFrameType::Key => {
                         frame_options.set_value(sys::kVTEncodeFrameOptionKey_ForceKeyFrame as _, Boolean::from(true).cf_type_ref() as _);
                     }
-                    EncodedFrameType::Auto | EncodedFrameType::Predicted => {}
+                    EncodedFrameType::Auto => {}
                 };
 
                 sys::VTCompressionSessionEncodeFrame(

--- a/x264/src/encoder.rs
+++ b/x264/src/encoder.rs
@@ -1,4 +1,4 @@
-use av_traits::{EncodedVideoFrame, RawVideoFrame, VideoEncoder, VideoEncoderOutput};
+use av_traits::{EncodedFrameType, EncodedVideoFrame, RawVideoFrame, VideoEncoder, VideoEncoderOutput};
 use snafu::Snafu;
 use std::{marker::PhantomData, mem};
 use x264_sys as sys;
@@ -142,7 +142,7 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for X264Encoder<F> {
     type Error = X264EncoderError;
     type RawVideoFrame = F;
 
-    fn encode(&mut self, input: F) -> Result<Option<VideoEncoderOutput<F>>> {
+    fn encode(&mut self, input: F, frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<F>>> {
         let mut pic = unsafe {
             let mut pic: mem::MaybeUninit<sys::x264_picture_t> = mem::MaybeUninit::uninit();
             sys::x264_picture_init(pic.as_mut_ptr());
@@ -168,6 +168,11 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for X264Encoder<F> {
         }
         pic.opaque = Box::into_raw(input) as _;
         pic.i_pts = self.frame_count as _;
+        pic.i_type = match frame_type {
+            EncodedFrameType::Auto => sys::X264_TYPE_AUTO as _,
+            EncodedFrameType::Key => sys::X264_TYPE_KEYFRAME as _,
+            EncodedFrameType::Predicted => sys::X264_TYPE_P as _,
+        };
         self.frame_count += 1;
         self.do_encode(Some(pic))
     }
@@ -221,7 +226,7 @@ mod test {
             let frame = TestFrame {
                 samples: vec![y, u.clone(), v.clone()],
             };
-            if let Some(mut output) = encoder.encode(frame).unwrap() {
+            if let Some(mut output) = encoder.encode(frame, EncodedFrameType::Auto).unwrap() {
                 encoded.append(&mut output.encoded_frame.data);
                 encoded_frames += 1;
             }
@@ -238,5 +243,37 @@ mod test {
         // To inspect the output, uncomment these lines:
         //use std::io::Write;
         //std::fs::File::create("tmp.h264").unwrap().write_all(&encoded).unwrap();
+    }
+
+    #[test]
+    fn test_video_encoder_with_encode_frame_type() {
+        let mut encoder = X264Encoder::new(X264EncoderConfig {
+            width: 1920,
+            height: 1080,
+            bitrate: Some(10000),
+            fps: 29.97,
+            input_format: X264EncoderInputFormat::Yuv420Planar,
+        })
+        .unwrap();
+
+        let u = vec![200u8; 1920 * 1080 / 4];
+        let v = vec![128u8; 1920 * 1080 / 4];
+        for i in 0..90 {
+            let mut y = Vec::with_capacity(1920 * 1080);
+            for line in 0..1080 {
+                let sample = if line / 12 == i {
+                    17
+                } else {
+                    (17.0 + (line as f64 / 1080.0) * 219.0).round() as u8
+                };
+                y.resize(y.len() + 1920, sample);
+            }
+            let frame = TestFrame {
+                samples: vec![y, u.clone(), v.clone()],
+            };
+            if let Some(output) = encoder.encode(frame, EncodedFrameType::Key).unwrap() {
+                assert!(output.encoded_frame.is_keyframe);
+            }
+        }
     }
 }

--- a/x264/src/encoder.rs
+++ b/x264/src/encoder.rs
@@ -171,7 +171,6 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for X264Encoder<F> {
         pic.i_type = match frame_type {
             EncodedFrameType::Auto => sys::X264_TYPE_AUTO as _,
             EncodedFrameType::Key => sys::X264_TYPE_KEYFRAME as _,
-            EncodedFrameType::Predicted => sys::X264_TYPE_P as _,
         };
         self.frame_count += 1;
         self.do_encode(Some(pic))

--- a/xcoder/xcoder-logan/src/encoder.rs
+++ b/xcoder/xcoder-logan/src/encoder.rs
@@ -280,13 +280,20 @@ impl<F: RawVideoFrame<u8>> XcoderEncoder<F> {
     /// Attempts to write the decoded frame to the encoder, performing cropping and scaling
     /// beforehand if necessary. If Some is returned, the caller must try again with the same
     /// frame later.
-    fn try_write_frame(&mut self, f: F) -> Result<Option<F>> {
+    fn try_write_frame(&mut self, f: F, force_key_frame: bool) -> Result<Option<F>> {
         if !self.frame_data_io_has_next_frame {
             let mut frame = unsafe { &mut self.frame_data_io.data.frame };
             frame.start_of_stream = if self.did_start { 0 } else { 1 };
             frame.extra_data_len = sys::NI_APP_ENC_FRAME_META_DATA_SIZE as _;
             frame.pts = self.frames_copied as _;
             frame.dts = frame.pts;
+            if force_key_frame {
+                frame.force_key_frame = 1;
+                frame.ni_pict_type = sys::PIC_TYPE_IDR;
+            } else {
+                frame.force_key_frame = 0;
+                frame.ni_pict_type = 0;
+            }
 
             for i in 0..3 {
                 let subsampling = match i {
@@ -342,10 +349,16 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for XcoderEncoder<F> {
     type Error = XcoderEncoderError;
     type RawVideoFrame = F;
 
-    fn encode(&mut self, mut input: F, _frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<F>>> {
+    fn encode(&mut self, mut input: F, frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<F>>> {
         loop {
             self.try_reading_encoded_frames()?;
-            match self.try_write_frame(input)? {
+            match self.try_write_frame(
+                input,
+                match frame_type {
+                    EncodedFrameType::Key => true,
+                    EncodedFrameType::Auto | EncodedFrameType::Predicted => false,
+                },
+            )? {
                 Some(frame) => input = frame,
                 None => break,
             }

--- a/xcoder/xcoder-logan/src/encoder.rs
+++ b/xcoder/xcoder-logan/src/encoder.rs
@@ -416,7 +416,7 @@ mod test {
             let frame = TestFrame {
                 samples: vec![y, u.clone(), v.clone()],
             };
-            if let Some(mut output) = encoder.encode(frame).unwrap() {
+            if let Some(mut output) = encoder.encode(frame, EncodedFrameType::Auto).unwrap() {
                 encoded.append(&mut output.encoded_frame.data);
                 encoded_frames += 1;
             }

--- a/xcoder/xcoder-logan/src/encoder.rs
+++ b/xcoder/xcoder-logan/src/encoder.rs
@@ -289,7 +289,7 @@ impl<F: RawVideoFrame<u8>> XcoderEncoder<F> {
             frame.dts = frame.pts;
             if force_key_frame {
                 frame.force_key_frame = 1;
-                frame.ni_pict_type = sys::PIC_TYPE_IDR;
+                frame.ni_pict_type = sys::ni_pic_type_t_PIC_TYPE_IDR;
             } else {
                 frame.force_key_frame = 0;
                 frame.ni_pict_type = 0;

--- a/xcoder/xcoder-logan/src/encoder.rs
+++ b/xcoder/xcoder-logan/src/encoder.rs
@@ -342,7 +342,7 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for XcoderEncoder<F> {
     type Error = XcoderEncoderError;
     type RawVideoFrame = F;
 
-    fn encode(&mut self, mut input: F) -> Result<Option<VideoEncoderOutput<F>>> {
+    fn encode(&mut self, mut input: F, _frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<F>>> {
         loop {
             self.try_reading_encoded_frames()?;
             match self.try_write_frame(input)? {

--- a/xcoder/xcoder-logan/src/encoder.rs
+++ b/xcoder/xcoder-logan/src/encoder.rs
@@ -356,7 +356,7 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for XcoderEncoder<F> {
                 input,
                 match frame_type {
                     EncodedFrameType::Key => true,
-                    EncodedFrameType::Auto | EncodedFrameType::Predicted => false,
+                    EncodedFrameType::Auto => false,
                 },
             )? {
                 Some(frame) => input = frame,

--- a/xcoder/xcoder-logan/src/encoder.rs
+++ b/xcoder/xcoder-logan/src/encoder.rs
@@ -1,4 +1,4 @@
-use av_traits::{EncodedVideoFrame, RawVideoFrame, VideoEncoder, VideoEncoderOutput};
+use av_traits::{EncodedFrameType, EncodedVideoFrame, RawVideoFrame, VideoEncoder, VideoEncoderOutput};
 use scopeguard::{guard, ScopeGuard};
 use snafu::Snafu;
 use std::{collections::VecDeque, mem};

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -425,7 +425,7 @@ mod test {
             let frame = TestFrame {
                 samples: vec![y, u.clone(), v.clone()],
             };
-            if let Some(mut output) = encoder.encode(frame).unwrap() {
+            if let Some(mut output) = encoder.encode(frame, EncodedFrameType::Auto).unwrap() {
                 encoded.append(&mut output.encoded_frame.data);
                 encoded_frames += 1;
             }

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -281,13 +281,20 @@ impl<F: RawVideoFrame<u8>> XcoderEncoder<F> {
     /// Attempts to write the decoded frame to the encoder, performing cropping and scaling
     /// beforehand if necessary. If Some is returned, the caller must try again with the same
     /// frame later.
-    fn try_write_frame(&mut self, f: F) -> Result<Option<F>> {
+    fn try_write_frame(&mut self, f: F, force_key_frame: bool) -> Result<Option<F>> {
         if !self.frame_data_io_has_next_frame {
             let mut frame = unsafe { &mut self.frame_data_io.data.frame };
             frame.start_of_stream = if self.did_start { 0 } else { 1 };
             frame.extra_data_len = sys::NI_APP_ENC_FRAME_META_DATA_SIZE as _;
             frame.pts = self.frames_copied as _;
             frame.dts = frame.pts;
+            if force_key_frame {
+                frame.force_key_frame = 1;
+                frame.ni_pict_type = sys::PIC_TYPE_IDR;
+            } else {
+                frame.force_key_frame = 0;
+                frame.ni_pict_type = 0;
+            }
 
             let mut dst_data = [frame.p_data[0] as *mut u8, frame.p_data[1] as *mut u8, frame.p_data[2] as *mut u8];
 
@@ -351,10 +358,16 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for XcoderEncoder<F> {
     type Error = XcoderEncoderError;
     type RawVideoFrame = F;
 
-    fn encode(&mut self, mut input: F, _frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<F>>> {
+    fn encode(&mut self, mut input: F, frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<F>>> {
         loop {
             self.try_reading_encoded_frames()?;
-            match self.try_write_frame(input)? {
+            match self.try_write_frame(
+                input,
+                match frame_type {
+                    EncodedFrameType::Key => true,
+                    EncodedFrameType::Auto | EncodedFrameType::Predicted => false,
+                },
+            )? {
                 Some(frame) => input = frame,
                 None => break,
             }

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -290,7 +290,7 @@ impl<F: RawVideoFrame<u8>> XcoderEncoder<F> {
             frame.dts = frame.pts;
             if force_key_frame {
                 frame.force_key_frame = 1;
-                frame.ni_pict_type = sys::PIC_TYPE_IDR;
+                frame.ni_pict_type = sys::ni_pic_type_t_PIC_TYPE_IDR;
             } else {
                 frame.force_key_frame = 0;
                 frame.ni_pict_type = 0;

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -1,4 +1,4 @@
-use av_traits::{EncodedVideoFrame, RawVideoFrame, VideoEncoder, VideoEncoderOutput};
+use av_traits::{EncodedFrameType, EncodedVideoFrame, RawVideoFrame, VideoEncoder, VideoEncoderOutput};
 use scopeguard::{guard, ScopeGuard};
 use snafu::Snafu;
 use std::{collections::VecDeque, mem};
@@ -351,7 +351,7 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for XcoderEncoder<F> {
     type Error = XcoderEncoderError;
     type RawVideoFrame = F;
 
-    fn encode(&mut self, mut input: F) -> Result<Option<VideoEncoderOutput<F>>> {
+    fn encode(&mut self, mut input: F, _frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<F>>> {
         loop {
             self.try_reading_encoded_frames()?;
             match self.try_write_frame(input)? {

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -365,7 +365,7 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for XcoderEncoder<F> {
                 input,
                 match frame_type {
                     EncodedFrameType::Key => true,
-                    EncodedFrameType::Auto | EncodedFrameType::Predicted => false,
+                    EncodedFrameType::Auto => false,
                 },
             )? {
                 Some(frame) => input = frame,


### PR DESCRIPTION
This adds a new parameter `EncodedFrameType` to `VideoEncoder::encode` API to allows users to explicitly specify encoded frame types for libx264 or Video Toolbox.

1. For x264 encoder, there is a direct mapping from `EncodedFrameType` to properties defined in x264
2. For Video Toolbox, [`kVTEncodeFrameOptionKey_ForceKeyFrame`](https://developer.apple.com/documentation/videotoolbox/kvtencodeframeoptionkey_forcekeyframe) property seems to be used to force the current encoded frame to be a key frame. But there are not corresponding properties for `Auto` and `Predicted`.  [`kVTEncodeFrameOptionKey_BaseFrameQP`](https://developer.apple.com/documentation/videotoolbox/kvtencodeframeoptionkey_baseframeqp) is another frame encoding option, but it's not clear what it is and how to use it.




