### PR TITLE
[AVS-288] derive PartialEq and Eq for enum EncodedFrameType

### DIFF
--- a/av-traits/src/video_encoder.rs
+++ b/av-traits/src/video_encoder.rs
@@ -16,6 +16,7 @@ pub struct VideoEncoderOutput<F> {
     pub encoded_frame: EncodedVideoFrame,
 }
 
+#[derive(Eq, PartialEq)]
 pub enum EncodedFrameType {
     Auto,
     Key,


### PR DESCRIPTION
Need equality comparisons for `EncodedFrameType`