### PR TITLE
[AVS-350] Update to Xilinx Video SDK v2.0

### DIFF
--- a/xilinx/Cargo.toml
+++ b/xilinx/Cargo.toml
@@ -14,5 +14,6 @@ simple-error = "0.2.1"
 bindgen = "0.*"
 
 [dev-dependencies]
+scopeguard = "1.1.0"
 h264 = { path = "../h264" }
 h265 = { path = "../h265" }

--- a/xilinx/src/xlnx_dec_utils.rs
+++ b/xilinx/src/xlnx_dec_utils.rs
@@ -24,6 +24,7 @@ pub struct XlnxDecoderXrmCtx {
 }
 
 /// Calculates the decoder load uing the xrmU30Dec plugin.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn xlnx_calc_dec_load(xrm_ctx: xrmContext, xma_dec_props: *mut XmaDecoderProperties) -> Result<i32, SimpleError> {
     let func_id = 0;
     let mut plugin_param: xrmPluginFuncParam = Default::default();

--- a/xilinx/src/xlnx_enc_utils.rs
+++ b/xilinx/src/xlnx_enc_utils.rs
@@ -15,6 +15,7 @@ pub struct XlnxEncoderXrmCtx {
 }
 
 /// Calculates the encoder load uing the xrmU30Enc plugin.
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn xlnx_calc_enc_load(xrm_ctx: xrmContext, xma_enc_props: *mut XmaEncoderProperties) -> Result<i32, SimpleError> {
     let func_id = 0;
     let mut plugin_param: xrmPluginFuncParam = Default::default();

--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -11,7 +11,8 @@ impl XlnxEncoder {
     pub fn new(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<Self, SimpleError> {
         let enc_session = xlnx_create_enc_session(xma_enc_props, xlnx_enc_ctx)?;
 
-        let out_buffer = unsafe { xma_data_buffer_alloc(0, true) };
+        let buffer_size = xma_enc_props.height * xma_enc_props.width * xma_enc_props.bits_per_pixel;
+        let out_buffer = unsafe { xma_data_buffer_alloc(buffer_size as u64, false) };
 
         Ok(Self {
             enc_session,
@@ -124,7 +125,7 @@ mod encoder_tests {
             custom_rc: 0,
             gop_mode: 0,
             gdr_mode: 0,
-            num_bframes: 2,
+            num_bframes: 0,
             idr_period: 120,
             profile,
             level,
@@ -138,8 +139,8 @@ mod encoder_tests {
             qp_mode: 1,
             filler_data: false,
             aspect_ratio: XlnxAspectRatio::AspectRatio16x9,
-            scaling_list: 1,
-            entropy_mode: 1,
+            scaling_list: 0,
+            entropy_mode: 0,
             loop_filter: true,
             constrained_intra_pred: false,
             prefetch_buffer: true,

--- a/xilinx/src/xlnx_scal_utils.rs
+++ b/xilinx/src/xlnx_scal_utils.rs
@@ -16,6 +16,7 @@ pub struct XlnxScalerXrmCtx {
     pub cu_res: xrmCuResource,
 }
 
+#[allow(clippy::not_unsafe_ptr_arg_deref)]
 pub fn xlnx_calc_scal_load(xrm_ctx: xrmContext, xma_scal_props: *mut XmaScalerProperties) -> Result<i32, SimpleError> {
     let func_id = 0;
     let mut plugin_param: xrmPluginFuncParam = Default::default();

--- a/xilinx/src/xlnx_transcoder_utils.rs
+++ b/xilinx/src/xlnx_transcoder_utils.rs
@@ -16,7 +16,7 @@ pub struct XlnxTranscodeXrmCtx {
 
 impl XlnxTranscodeXrmCtx {
     pub fn new() -> Self {
-        let xrm_ctx = unsafe {xrmCreateContext(XRM_API_VERSION_1)};
+        let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
 
         Self {
             xrm_ctx,
@@ -24,9 +24,9 @@ impl XlnxTranscodeXrmCtx {
                 dec_load: 0,
                 scal_load: 0,
                 enc_load: 0,
-                enc_num:0,
+                enc_num: 0,
             },
-            reserve_idx: 0 
+            reserve_idx: 0,
         }
     }
 }
@@ -121,6 +121,12 @@ pub fn xlnx_reserve_transcode_resource(
     }
 
     Ok(())
+}
+
+impl Default for XlnxTranscodeXrmCtx {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl Drop for XlnxTranscodeXrmCtx {


### PR DESCRIPTION
**What it does**

- Updates the Xilinx crate to be compatible with Video SDK to V2.0. 
- The Encoder object now allocates and owns a buffer the size of a raw frame to receive frames from hardware
- Makes small changes to encoder unit tests to eliminate new warning messages introduced in SDK V2.0
- Fixes broken test scaler test case by adding proper buffer flushing 
- Cleans up clippy warning messages.

**How to test** 
cargo test 
