### PR TITLE
xcoder leak fixes

### DIFF
--- a/xcoder/xcoder-logan/xcoder-logan-sys/vendor/libxcoder/source/ni_rsrc_api.cpp
+++ b/xcoder/xcoder-logan/xcoder-logan-sys/vendor/libxcoder/source/ni_rsrc_api.cpp
@@ -3561,5 +3561,8 @@ int ni_rsrc_unlock(int device_type, ni_lock_handle_t lock)
     }
     while (status != NI_RETCODE_SUCCESS);
   }
+#ifdef __linux__
+  close(lock);
+#endif   //__linux__ defined
   return NI_RETCODE_SUCCESS;
 }

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -188,6 +188,8 @@ impl<F> XcoderEncoder<F> {
             }
             let did_finish = guard(false, |did_finish| {
                 sys::ni_device_session_close(*session, if did_finish { 1 } else { 0 }, sys::ni_device_type_t_NI_DEVICE_TYPE_ENCODER);
+                sys::ni_device_close((**session).device_handle);
+                sys::ni_device_close((**session).blk_io_handle);
             });
 
             let frame_data_io = {
@@ -349,6 +351,8 @@ impl<F> Drop for XcoderEncoder<F> {
         unsafe {
             sys::ni_frame_buffer_free(&mut self.frame_data_io.data.frame as _);
             sys::ni_device_session_close(self.session, if self.did_finish { 1 } else { 0 }, sys::ni_device_type_t_NI_DEVICE_TYPE_ENCODER);
+            sys::ni_device_close((*self.session).device_handle);
+            sys::ni_device_close((*self.session).blk_io_handle);
             sys::ni_device_session_context_free(self.session);
         }
     }


### PR DESCRIPTION
Previously creating and closing an encoder session leaked three file descriptors. This fixes all of those leaks and adds a test.