### PR TITLE
add gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+xilinx/src/testdata/smptebars.yuv filter=lfs diff=lfs merge=lfs -text


### PR DESCRIPTION
Not sure why git lfs behaves differently on Linux, but this seems to be necessary to keep it from thinking the .yuv file is modified.