### PR TITLE
expand xcoder quadra features

### DIFF
--- a/xcoder/xcoder-quadra/src/decoder.rs
+++ b/xcoder/xcoder-quadra/src/decoder.rs
@@ -462,7 +462,11 @@ pub mod test {
             height: 720,
             fps: 29.97,
             bitrate: None,
-            codec: XcoderEncoderCodec::H264,
+            codec: XcoderEncoderCodec::H264 {
+                profile: None,
+                level_idc: None,
+            },
+            bit_depth: 8,
             hardware: Some(decoder.hardware()),
         })
         .unwrap();

--- a/xcoder/xcoder-quadra/src/lib.rs
+++ b/xcoder/xcoder-quadra/src/lib.rs
@@ -43,6 +43,10 @@ mod linux_impl {
         pub fn surface(&self) -> &sys::niFrameSurface1_t {
             unsafe { &*((*self).p_data[3] as *const sys::niFrameSurface1_t) }
         }
+
+        unsafe fn surface_mut(&mut self) -> &mut sys::niFrameSurface1_t {
+            &mut *((*self).p_data[3] as *mut sys::niFrameSurface1_t)
+        }
     }
 
     unsafe impl Send for XcoderHardwareFrame {}
@@ -125,6 +129,7 @@ mod test {
             hardware: decoder.hardware(),
             width: 640,
             height: 360,
+            bit_depth: 8,
         })
         .unwrap();
 
@@ -133,7 +138,11 @@ mod test {
             height: 360,
             fps: 29.97,
             bitrate: None,
-            codec: XcoderEncoderCodec::H264,
+            codec: XcoderEncoderCodec::H264 {
+                profile: None,
+                level_idc: None,
+            },
+            bit_depth: 8,
             hardware: Some(decoder.hardware()),
         })
         .unwrap();
@@ -205,6 +214,7 @@ mod test {
                 hardware: decoder.hardware(),
                 width: 640,
                 height: 360,
+                bit_depth: 8,
             })
             .unwrap();
 
@@ -213,7 +223,11 @@ mod test {
                 height: 360,
                 fps: 24.0,
                 bitrate: None,
-                codec: XcoderEncoderCodec::H264,
+                codec: XcoderEncoderCodec::H264 {
+                    profile: None,
+                    level_idc: None,
+                },
+                bit_depth: 8,
                 hardware: Some(decoder.hardware()),
             })
             .unwrap();

--- a/xcoder/xcoder-quadra/xcoder-quadra-sys/src/lib.hpp
+++ b/xcoder/xcoder-quadra/xcoder-quadra-sys/src/lib.hpp
@@ -3,3 +3,4 @@
 #include <ni_util.h>
 
 const int GC620_I420_ = GC620_I420;
+const int GC620_I010_ = GC620_I010;


### PR DESCRIPTION
* Adds the ability to specify profile and level to the encoder.
* Adds the ability to specify target bit depth to the scaler.
* Fixes a memory leak in the encoder.
* Makes everything `Send`.