### PR TITLE
xcoder-logan release build fix

### DIFF
--- a/xcoder/xcoder-logan/xcoder-logan-sys/build.rs
+++ b/xcoder/xcoder-logan/xcoder-logan-sys/build.rs
@@ -59,6 +59,8 @@ fn main() {
             .flag("-fPIC")
             .flag("-Werror")
             .flag("-Wno-unused-command-line-argument")
+            .flag("-Wno-format-overflow")
+            .flag("-Wno-stringop-overflow")
             .compile("xcoder-cpp-sys");
 
         let bindings = bindgen::Builder::default();


### PR DESCRIPTION
With `-O3` optimizations on, GCC complains about some warnings that it doesn't notice in debug mode. That causes compilation to fail. This adds exceptions for those warnings (which are in NETINT code).