### PR TITLE
add LIBXCODER_OBJS_BUILD define to cpp files

### DIFF
--- a/xcoder/xcoder-logan/xcoder-logan-sys/build.rs
+++ b/xcoder/xcoder-logan/xcoder-logan-sys/build.rs
@@ -61,6 +61,7 @@ fn main() {
             .flag("-Wno-unused-command-line-argument")
             .flag("-Wno-format-overflow")
             .flag("-Wno-stringop-overflow")
+            .flag("-DLIBXCODER_OBJS_BUILD")
             .compile("xcoder-cpp-sys");
 
         let bindings = bindgen::Builder::default();

--- a/xcoder/xcoder-quadra/xcoder-quadra-sys/build.rs
+++ b/xcoder/xcoder-quadra/xcoder-quadra-sys/build.rs
@@ -55,6 +55,7 @@ fn main() {
             .flag("-fPIC")
             .flag("-Werror")
             .flag("-Wno-unused-command-line-argument")
+            .flag("-DLIBXCODER_OBJS_BUILD")
             .compile("xcoder-cpp-sys");
 
         let bindings = bindgen::Builder::default();


### PR DESCRIPTION
I was adding this define for the C files, but not CPP files, which for logan at least was causing `ni_rsrc_init` to behave in unexpected ways.