### PR TITLE
add api for getting srt stats

### DIFF
--- a/srt/srt-sys/Cargo.toml
+++ b/srt/srt-sys/Cargo.toml
@@ -13,3 +13,5 @@ libc = "0.2.71"
 
 [build-dependencies]
 cmake = "0.1"
+# We're very permissive here with bindgen due to https://github.com/rust-lang/cargo/issues/5237
+bindgen = "0.*"

--- a/srt/srt-sys/build.rs
+++ b/srt/srt-sys/build.rs
@@ -43,4 +43,17 @@ fn main() {
         }
         _ => {}
     }
+
+    // the "whilelist_" functions have been renamed in newer bindgen versions, but we use the
+    // old names for wider compatibility
+    #[allow(deprecated)]
+    let bindings = bindgen::Builder::default()
+        .header(format!("{}/include/srt/srt.h", build.display()))
+        .whitelist_function("srt_.+")
+        .whitelist_type("SRT_.+")
+        .generate()
+        .expect("unable to generate bindings");
+
+    let out_path = std::path::PathBuf::from(std::env::var("OUT_DIR").unwrap());
+    bindings.write_to_file(out_path.join("bindings.rs")).expect("unable to write bindings");
 }

--- a/srt/srt-sys/src/lib.rs
+++ b/srt/srt-sys/src/lib.rs
@@ -1,86 +1,14 @@
-// our naming mimicks the srt library
-#![allow(clippy::upper_case_acronyms)]
+#![allow(
+    deref_nullptr,
+    non_snake_case,
+    non_upper_case_globals,
+    non_camel_case_types,
+    clippy::unreadable_literal,
+    clippy::cognitive_complexity
+)]
+include!(concat!(env!("OUT_DIR"), "/bindings.rs"));
 
-pub use libc::{c_char as char, c_int as int, c_void as void, sockaddr, sockaddr_storage, socklen_t};
-
-pub type SRTSOCKET = int;
-
-#[cfg(feature = "async")]
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum SRT_EPOLL_OPT {
-    SRT_EPOLL_IN = 1,
-    SRT_EPOLL_OUT = 4,
-    SRT_EPOLL_ERR = 8,
-}
-
-#[cfg(feature = "async")]
-pub type SYSSOCKET = int;
-
-#[repr(C)]
-#[allow(non_camel_case_types)]
-pub enum SRT_SOCKOPT {
-    #[cfg(feature = "async")]
-    SNDSYN = 1,
-    #[cfg(feature = "async")]
-    RCVSYN = 2,
-    RCVBUF = 6,
-    #[cfg(feature = "async")]
-    EVENT = 18,
-    TSBPDMODE = 22,
-    PASSPHRASE = 26,
-    TLPKTDROP = 31,
-    STREAMID = 46,
-}
-
-extern "C" {
-    pub fn srt_startup() -> int;
-    pub fn srt_cleanup() -> int;
-
-    pub fn srt_getlasterror(errno_loc: *mut int) -> int;
-
-    pub fn srt_create_socket() -> SRTSOCKET;
-    pub fn srt_close(u: SRTSOCKET) -> int;
-
-    pub fn srt_bind(u: SRTSOCKET, name: *const sockaddr, namelen: int) -> int;
-    pub fn srt_listen(u: SRTSOCKET, backlog: int) -> int;
-    pub fn srt_accept(u: SRTSOCKET, addr: *mut sockaddr, addrlen: *mut int) -> SRTSOCKET;
-    pub fn srt_connect(u: SRTSOCKET, name: *const sockaddr, namelen: int) -> int;
-
-    pub fn srt_recv(u: SRTSOCKET, buf: *mut char, len: int) -> int;
-    pub fn srt_send(u: SRTSOCKET, buf: *const char, len: int) -> int;
-
-    pub fn srt_setsockopt(u: SRTSOCKET, level: int, optname: SRT_SOCKOPT, optval: *const void, optlen: int) -> int;
-    pub fn srt_getsockopt(u: SRTSOCKET, level: int, optname: SRT_SOCKOPT, optval: *mut void, optlen: *mut int) -> int;
-
-    pub fn srt_listen_callback(
-        lsn: SRTSOCKET,
-        hook_fn: extern "C" fn(*mut void, SRTSOCKET, int, *const sockaddr, *const char) -> int,
-        hook_opaque: *mut void,
-    ) -> int;
-}
-
-#[cfg(feature = "async")]
-extern "C" {
-    pub fn srt_epoll_create() -> int;
-    pub fn srt_epoll_release(eid: int) -> int;
-    pub fn srt_epoll_add_ssock(eid: int, s: SYSSOCKET, events: *const int) -> int;
-    pub fn srt_epoll_add_usock(eid: int, s: SRTSOCKET, events: *const int) -> int;
-    pub fn srt_epoll_update_usock(eid: int, s: SRTSOCKET, events: *const int) -> int;
-    pub fn srt_epoll_remove_usock(eid: int, s: SRTSOCKET) -> int;
-    pub fn srt_epoll_wait(
-        eid: int,
-        readfds: *mut SRTSOCKET,
-        rnum: *mut int,
-        writefds: *mut SRTSOCKET,
-        wnum: *mut int,
-        ms_timeout: i64,
-        lrfds: *mut SYSSOCKET,
-        lrnum: *mut int,
-        lwfds: *mut SYSSOCKET,
-        lwnum: *mut int,
-    ) -> int;
-}
+pub use libc::{c_char as char, c_int as int, c_void as void, sockaddr_storage, socklen_t};
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
Slightly begrudgingly, I've given in and switched this crate to use bindgen.

I've added an API to get SRT's raw socket stats.

And I've made it so we no longer call `srt_epoll_remove_usock` twice in a row for sockets that disconnect with an error while we're only waiting on a read. This was harmless but was making SRT put errors in our logs.