### PR TITLE
add h264 vui and sei encoding

### DIFF
--- a/h264/src/bitstream.rs
+++ b/h264/src/bitstream.rs
@@ -158,6 +158,15 @@ impl<T: io::Write> BitstreamWriter<T> {
         Ok(())
     }
 
+    // Writes the given bytes to the bitstream. The bitstream must be byte aligned.
+    pub fn write_bytes(&mut self, data: &[u8]) -> io::Result<()> {
+        if !self.byte_aligned() {
+            return Err(io::Error::new(io::ErrorKind::Other, "bitstream is not byte aligned"));
+        }
+        self.inner.write_all(data)?;
+        Ok(())
+    }
+
     // Writes the remaining bits to the underlying writer if there are any, and flushes it. If the
     // bitstream is not byte-aligned, zero-bits will be appended until it is.
     pub fn flush(&mut self) -> io::Result<()> {
@@ -167,6 +176,10 @@ impl<T: io::Write> BitstreamWriter<T> {
             self.next_bits_length = 0;
         }
         self.inner.flush()
+    }
+
+    pub fn unwritten_bits(&self) -> usize {
+        self.next_bits_length
     }
 
     pub fn inner(&self) -> &T {

--- a/h264/src/syntax_elements.rs
+++ b/h264/src/syntax_elements.rs
@@ -5,7 +5,7 @@ use std::io;
 // ITU-T H.264, 04/2017, 7.2
 macro_rules! define_syntax_element_u {
     ($e:ident, $t:tt, $n:literal) => {
-        #[derive(Clone, Copy, Debug, Default)]
+        #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
         pub struct $e(pub $t);
 
         impl Decode for $e {
@@ -38,7 +38,7 @@ define_syntax_element_u!(U48, u64, 48);
 define_syntax_element_u!(F1, u8, 1);
 
 // ITU-T H.264, 04/2017, 7.2 / 9.1
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct UE(pub u64);
 
 impl Decode for UE {
@@ -58,7 +58,7 @@ impl Encode for UE {
     }
 }
 
-#[derive(Debug, Default, Clone, Copy)]
+#[derive(Debug, Default, Clone, Copy, Eq, PartialEq)]
 pub struct SE(pub i64);
 
 impl Decode for SE {


### PR DESCRIPTION
This adds encoding of VUI parameters and SEI pic timing messages to the h264 crate.

To help make things nicer, it also derives more and makes `RBSP` an `IntoIterator`.