### PR TITLE
update rust to 1.63

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install Rust
       uses: actions-rs/toolchain@v1
       with:
-        toolchain: 1.60.0
+        toolchain: 1.63.0
         components: clippy
         override: true
     - name: Build
@@ -54,7 +54,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
+          toolchain: 1.63.0
           override: true
       - name: Initialize
         run: |
@@ -77,7 +77,7 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: 1.60.0
+          toolchain: 1.63.0
           override: true
       - name: Initialize
         run: |

--- a/h264/src/nal_unit.rs
+++ b/h264/src/nal_unit.rs
@@ -119,7 +119,7 @@ impl<T: Iterator<Item = u8>> EmulationPrevention<T> {
     }
 }
 
-impl<'a, T: Iterator<Item = u8>> Iterator for &mut EmulationPrevention<T> {
+impl<T: Iterator<Item = u8>> Iterator for &mut EmulationPrevention<T> {
     type Item = u8;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/hmp/src/api.rs
+++ b/hmp/src/api.rs
@@ -44,7 +44,7 @@ pub enum Content {
     Other,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SectionContentResponseBody {
     pub data: Vec<Content>,
@@ -80,7 +80,7 @@ fn deserialize_srt_details<'de, D: Deserializer<'de>>(deserializer: D) -> Result
     SRTEndpointDetailsWrapper::deserialize(deserializer).map(|w| w.srt)
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Endpoint {
     pub uri: String,
@@ -88,7 +88,7 @@ pub struct Endpoint {
     pub details: EndpointDetails,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct PlayerEndpointResponseBody {
     pub data: Vec<Endpoint>,

--- a/hmp/src/api.rs
+++ b/hmp/src/api.rs
@@ -7,34 +7,34 @@ pub struct LoginRequestBody<'a> {
     pub password: &'a str,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Section {
     pub name: String,
     pub id: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct SectionsResponseBody {
     pub data: Vec<Section>,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Source {
     pub name: String,
     pub id: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 pub struct Asset {
     pub title: String,
     pub id: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase")]
 #[serde(tag = "itemType")]
 pub enum Content {
@@ -50,7 +50,7 @@ pub struct SectionContentResponseBody {
     pub data: Vec<Content>,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 #[serde(default, rename_all = "camelCase")]
 pub struct SRTEndpointDetails {
     #[serde(rename = "srtMode")]
@@ -63,7 +63,7 @@ pub struct SRTEndpointDetails {
     pub passphrase: String,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", tag = "type")]
 pub enum EndpointDetails {
     #[serde(deserialize_with = "deserialize_srt_details", rename = "srt")]

--- a/mpeg2/src/pes.rs
+++ b/mpeg2/src/pes.rs
@@ -5,7 +5,7 @@ use alloc::{borrow::Cow, vec::Vec};
 use core::mem;
 use core2::io::Write;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Packet<'a> {
     pub header: PacketHeader,
     pub data: Cow<'a, [u8]>,

--- a/mpeg2/src/pes.rs
+++ b/mpeg2/src/pes.rs
@@ -82,7 +82,7 @@ impl<'a> Iterator for Packetize<'a> {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct PacketHeader {
     pub stream_id: u8,
     pub optional_header: Option<OptionalHeader>,
@@ -154,7 +154,7 @@ impl PacketHeader {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct OptionalHeader {
     pub data_alignment_indicator: bool,
     pub pts: Option<u64>,

--- a/mpeg2/src/temi.rs
+++ b/mpeg2/src/temi.rs
@@ -3,7 +3,7 @@ use crate::{DecodeError, EncodeError};
 
 pub const AF_DESCR_TAG_TIMELINE: u8 = 0x04;
 
-#[derive(Debug, PartialEq, PartialOrd, Copy, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Copy, Clone)]
 pub enum TimeFieldLength {
     None = 0,
     Short = 1,
@@ -17,7 +17,7 @@ impl Default for TimeFieldLength {
     }
 }
 
-#[derive(Debug, Default, PartialEq, Clone)]
+#[derive(Debug, Default, PartialEq, Eq, Clone)]
 pub struct TEMITimelineDescriptor {
     pub has_timestamp: TimeFieldLength,
     pub timescale: u32,

--- a/mpeg2/src/ts.rs
+++ b/mpeg2/src/ts.rs
@@ -208,7 +208,7 @@ impl AdaptationField {
 pub const TABLE_ID_PAT: u8 = 0;
 pub const TABLE_ID_PMT: u8 = 2;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TableSection<'a> {
     pub table_id: u8,
     pub section_syntax_indicator: bool,
@@ -308,7 +308,7 @@ impl<'a> TableSection<'a> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct TableSyntaxSection<'a> {
     pub table_id_extension: u16,
     pub data: &'a [u8],
@@ -336,7 +336,7 @@ impl<'a> TableSyntaxSection<'a> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PATEntry {
     pub program_number: u16,
     pub program_map_pid: u16,
@@ -364,7 +364,7 @@ impl PATEntry {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PATData {
     pub entries: Vec<PATEntry>,
 }
@@ -385,7 +385,7 @@ impl PATData {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PMTElementaryStreamInfo<'a> {
     pub stream_type: u8,
     pub elementary_pid: u16,
@@ -423,7 +423,7 @@ impl<'a> PMTElementaryStreamInfo<'a> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct PMTData<'a> {
     pub pcr_pid: u16,
     pub elementary_stream_info: Vec<PMTElementaryStreamInfo<'a>>,

--- a/mpeg2/src/ts.rs
+++ b/mpeg2/src/ts.rs
@@ -6,7 +6,7 @@ use core2::io::Write;
 
 pub const PID_PAT: u16 = 0x00;
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub struct Packet<'a> {
     pub packet_id: u16,
     pub payload_unit_start_indicator: bool,
@@ -15,7 +15,7 @@ pub struct Packet<'a> {
     pub payload: Option<Cow<'a, [u8]>>,
 }
 
-#[derive(Debug, Default, PartialEq)]
+#[derive(Debug, Default, PartialEq, Eq)]
 pub struct AdaptationField {
     pub discontinuity_indicator: Option<bool>,
     pub random_access_indicator: Option<bool>,

--- a/mpeg4/src/lib.rs
+++ b/mpeg4/src/lib.rs
@@ -9,7 +9,7 @@ use byteorder::{BigEndian, ReadBytesExt};
 pub use core2::io;
 use core2::io::Read;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AVCDecoderConfigurationRecord {
     pub configuration_version: u8,
     pub avc_profile_indication: u8,
@@ -57,7 +57,7 @@ impl AVCDecoderConfigurationRecord {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HVCDecoderConfigurationRecord {
     pub configuration_version: u8,
     pub general_profile_space: u8,
@@ -140,7 +140,7 @@ impl HVCDecoderConfigurationRecord {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AudioSpecificConfig {
     pub object_type: u16,
 }
@@ -272,7 +272,7 @@ impl<'a> DecoderConfigDescriptorData<'a> {
     }
 }
 
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum AudioDataTransportStreamMPEGVersion {
     MPEG4,
     MPEG2,

--- a/mpegts-segmenter/src/analyzer.rs
+++ b/mpegts-segmenter/src/analyzer.rs
@@ -5,7 +5,7 @@ use std::{collections::VecDeque, error::Error};
 
 pub type Result<T> = std::result::Result<T, Box<dyn Error + Send + Sync>>;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Timecode {
     pub hours: u8,
     pub minutes: u8,

--- a/qtff/src/data.rs
+++ b/qtff/src/data.rs
@@ -262,7 +262,7 @@ impl ReadData for MediaData {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct MediaHeaderData {
     pub version: u8,
     pub flags: [u8; 3],
@@ -278,7 +278,7 @@ impl AtomData for MediaHeaderData {
     const TYPE: FourCC = FourCC::MDHD;
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct HandlerReferenceData {
     pub version: u8,
     pub flags: [u8; 3],
@@ -293,7 +293,7 @@ impl AtomData for HandlerReferenceData {
     const TYPE: FourCC = FourCC::HDLR;
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub struct ChunkOffset64Data {
     pub version: u8,
     pub flags: [u8; 3],
@@ -304,7 +304,7 @@ impl AtomData for ChunkOffset64Data {
     const TYPE: FourCC = FourCC::CO64;
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 pub struct ChunkOffsetData {
     pub version: u8,
     pub flags: [u8; 3],
@@ -315,7 +315,7 @@ impl AtomData for ChunkOffsetData {
     const TYPE: FourCC = FourCC::STCO;
 }
 
-#[derive(Clone, Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct SampleSizeData {
     pub version: u8,
     pub flags: [u8; 3],
@@ -416,13 +416,13 @@ impl SampleSizeData {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct TimeToSampleDataEntry {
     pub sample_count: u32,
     pub sample_duration: u32,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub struct TimeToSampleData {
     pub version: u8,
     pub flags: [u8; 3],
@@ -482,14 +482,14 @@ impl TimeToSampleData {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub struct SampleToChunkDataEntry {
     pub first_chunk: u32,
     pub samples_per_chunk: u32,
     pub sample_description_id: u32,
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 pub struct SampleToChunkData {
     pub version: u8,
     pub flags: [u8; 3],
@@ -675,10 +675,10 @@ pub trait MediaType: fmt::Debug {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct GeneralMediaType;
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct GeneralSampleDescriptionDataEntry {
     pub data_format: u32,
     pub reserved: [u8; 6],
@@ -689,7 +689,7 @@ impl MediaType for GeneralMediaType {
     type SampleDescriptionDataEntry = GeneralSampleDescriptionDataEntry;
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VideoMediaType;
 
 #[derive(Clone, Debug, PartialEq)]
@@ -744,7 +744,7 @@ impl ReadData for VideoSampleDescriptionDataEntry {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct VideoSampleDescriptionDataEntryExtensions {
     pub avc_decoder_configuration: Option<AVCDecoderConfigurationData>,
     pub hvc_decoder_configuration: Option<HVCDecoderConfigurationData>,
@@ -759,7 +759,7 @@ impl ReadData for VideoSampleDescriptionDataEntryExtensions {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct AVCDecoderConfigurationData {
     pub record: Vec<u8>,
 }
@@ -776,7 +776,7 @@ impl ReadData for AVCDecoderConfigurationData {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct HVCDecoderConfigurationData {
     pub record: Vec<u8>,
 }
@@ -818,17 +818,17 @@ impl ReadData for VideoMediaInformationData {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct VideoMediaInformationHeaderData {}
 
 impl AtomData for VideoMediaInformationHeaderData {
     const TYPE: FourCC = FourCC::VMHD;
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SoundMediaType;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct ElementaryStreamDescriptorData {
     pub version: u32,
     pub descriptor: Vec<u8>,
@@ -851,7 +851,7 @@ impl ReadData for ElementaryStreamDescriptorData {
     }
 }
 
-#[derive(Clone, Default, Debug, PartialEq)]
+#[derive(Clone, Default, Debug, PartialEq, Eq)]
 pub struct SoundSampleDescriptionDataEntryExtensions {
     pub elementary_stream_descriptor: Option<ElementaryStreamDescriptorData>,
 }
@@ -936,7 +936,7 @@ impl ReadData for SoundSampleDescriptionDataEntryV1 {
     }
 }
 
-#[derive(Clone, Debug, Default, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq)]
 pub struct SoundSampleDescriptionDataEntryV2 {
     // TODO: add v2 fields. the docs i'm looking at right now seem to be confused about whether v2
 // appends new fields to v1 or replaces fields in v1 :-/
@@ -1013,14 +1013,14 @@ impl ReadData for SoundMediaInformationData {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct SoundMediaInformationHeaderData {}
 
 impl AtomData for SoundMediaInformationHeaderData {
     const TYPE: FourCC = FourCC::SMHD;
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TimecodeMediaType;
 
 pub enum TimecodeSampleDescriptionFlags {
@@ -1030,7 +1030,7 @@ pub enum TimecodeSampleDescriptionFlags {
     Counter = 0x0008,
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct TimecodeSampleDescriptionDataEntry {
     pub data_format: u32,
     pub reserved: [u8; 6],
@@ -1043,7 +1043,7 @@ pub struct TimecodeSampleDescriptionDataEntry {
     pub reserved3: u8,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub enum TimecodeSample {
     Counter(u32),
     Timecode(Timecode),
@@ -1064,7 +1064,7 @@ impl TimecodeSample {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Timecode {
     pub negative: bool,
     pub hours: u8,
@@ -1094,7 +1094,7 @@ impl Timecode {
     }
 
     pub fn from_frame_number(n: i64, fps: f64) -> Timecode {
-        let abs_number = n.abs() as u64;
+        let abs_number = n.unsigned_abs();
         if (fps.round() - fps).abs() > std::f64::EPSILON {
             let fp10m = (fps * 600.0).round() as u64;
             let ten_minutes = abs_number / fp10m;
@@ -1197,7 +1197,7 @@ impl<M: MediaType> ReadData for BaseMediaInformationData<M> {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct BaseMediaInformationHeaderData {}
 
 impl AtomData for BaseMediaInformationHeaderData {
@@ -1417,7 +1417,7 @@ impl MetadataData {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct MetadataHandlerData {
     pub version: u8,
     pub flags: [u8; 3],
@@ -1429,13 +1429,13 @@ impl AtomData for MetadataHandlerData {
     const TYPE: FourCC = FourCC::HDLR;
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MetadataItemKeysDataEntry {
     pub key_namespace: u32,
     pub key_value: Vec<u8>,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct MetadataItemKeysData {
     pub entries: Vec<MetadataItemKeysDataEntry>,
 }
@@ -1578,28 +1578,28 @@ impl ReadData for MetadataItemListData {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct TrackReferenceData {}
 
 impl AtomData for TrackReferenceData {
     const TYPE: FourCC = FourCC::TREF;
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct ExtendedLanguageTagData {}
 
 impl AtomData for ExtendedLanguageTagData {
     const TYPE: FourCC = FourCC::ELNG;
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct DataInformationData {}
 
 impl AtomData for DataInformationData {
     const TYPE: FourCC = FourCC::DINF;
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq)]
 pub struct UserDataData {}
 
 impl AtomData for UserDataData {

--- a/srt/src/async_lib.rs
+++ b/srt/src/async_lib.rs
@@ -164,7 +164,7 @@ struct Connect {
     state: State<AsyncStream>,
 }
 
-impl<'a> Future for Connect {
+impl Future for Connect {
     type Output = Result<AsyncStream>;
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {

--- a/xcoder/xcoder-logan/xcoder-logan-sys/src/lib.rs
+++ b/xcoder/xcoder-logan/xcoder-logan-sys/src/lib.rs
@@ -6,7 +6,8 @@
     non_camel_case_types,
     unaligned_references,
     clippy::redundant_static_lifetimes,
-    clippy::too_many_arguments
+    clippy::too_many_arguments,
+    clippy::useless_transmute
 )]
 
 #[cfg(target_os = "linux")]

--- a/xcoder/xcoder-quadra/xcoder-quadra-sys/src/lib.rs
+++ b/xcoder/xcoder-quadra/xcoder-quadra-sys/src/lib.rs
@@ -6,7 +6,8 @@
     non_camel_case_types,
     unaligned_references,
     clippy::redundant_static_lifetimes,
-    clippy::too_many_arguments
+    clippy::too_many_arguments,
+    clippy::useless_transmute
 )]
 
 #[cfg(target_os = "linux")]


### PR DESCRIPTION
Got tired of the clippy warnings I was seeing locally.

Also 1.63 [might be 10-15% faster](https://perf.rust-lang.org/dashboard.html)?