### PR TITLE
ffmpeg error wrapper

### DIFF
--- a/ffmpeg/src/avutil/mod.rs
+++ b/ffmpeg/src/avutil/mod.rs
@@ -1,7 +1,6 @@
 use std::{ffi::CStr, os::raw::c_int};
 
 #[derive(Copy, Clone, PartialEq, Eq)]
-#[repr(transparent)]
 pub struct Error(pub c_int);
 
 impl Error {

--- a/ffmpeg/src/avutil/mod.rs
+++ b/ffmpeg/src/avutil/mod.rs
@@ -1,0 +1,62 @@
+use std::{ffi::CStr, os::raw::c_int};
+
+#[derive(Copy, Clone, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct Error(pub c_int);
+
+impl Error {
+    /// Wraps a ffmpeg return value that is negative iff there was an error.
+    #[inline]
+    pub fn wrap(raw: c_int) -> Result<c_int, Self> {
+        if raw < 0 {
+            return Err(Self(raw));
+        }
+        Ok(raw)
+    }
+}
+
+impl std::error::Error for Error {}
+
+impl std::fmt::Debug for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "Error({} /* {} */)", self.0, self)
+    }
+}
+
+impl std::fmt::Display for Error {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        const ARRAYLEN: usize = 64;
+        let mut buf = [0; ARRAYLEN];
+        let s = unsafe {
+            // Note av_strerror uses strlcpy, so it guarantees a trailing NUL byte.
+            ffmpeg_sys::av_strerror(self.0, buf.as_mut_ptr(), ARRAYLEN);
+            CStr::from_ptr(buf.as_ptr())
+        };
+        f.write_str(&s.to_string_lossy())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::ffi::CString;
+
+    use super::*;
+
+    #[test]
+    fn test_error() {
+        let eof_formatted = format!("{}", Error(ffmpeg_sys::AVERROR_EOF));
+        assert!(eof_formatted.contains("End of file"), "eof formatted is: {}", eof_formatted);
+
+        // Debug should have both the number and the string.
+        let eof_debug = format!("{:?}", Error(ffmpeg_sys::AVERROR_EOF));
+        assert!(
+            eof_debug.contains(&format!("{}", ffmpeg_sys::AVERROR_EOF)) && eof_debug.contains("End of file"),
+            "eof debug is: {}",
+            &eof_debug
+        );
+
+        // Errors should be round trippable to a CString. (This will fail if they contain NUL
+        // bytes.)
+        CString::new(eof_formatted).unwrap();
+    }
+}

--- a/ffmpeg/src/lib.rs
+++ b/ffmpeg/src/lib.rs
@@ -2,5 +2,8 @@
 extern crate thiserror;
 
 pub mod avformat;
+pub mod avutil;
 
 pub use ffmpeg_sys as sys;
+
+pub use avutil::Error;


### PR DESCRIPTION
It's frustrating to see failures without the error message, so let's make propagating that easy.

E.g., this old code:

```rust
if av... < 0 {
    bail!("av... failed");
}
```

can become this:

```rust
if let Err(e) = ffmpeg::Error::wrap(av...) {
    bail!("av... failed: {}", e);
}
```

or `ffmpeg::Error::wrap(av...).map_err(...)?`.

This is mostly lifted from my similar code here:

impl https://github.com/scottlamb/moonfire-ffmpeg/blob/ab1fad1c9ed6c9d37f6c39135f797f3a0fa91941/src/avutil.rs#L262-L323 test https://github.com/scottlamb/moonfire-ffmpeg/blob/ab1fad1c9ed6c9d37f6c39135f797f3a0fa91941/src/avutil.rs#L425-L449

It's slightly simpler because callers can just use `ffmpeg_sys::AVERROR_*` instead of this code exposing the constants as I did in my `moonfire-ffmpeg` crate. I just made the inner int pub too.