### PR TITLE
ffmpeg crate: pass through features to ffmpeg-sys

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --workspace --exclude xilinx --features srt/async --exclude xcoder-quadra --exclude xcoder-logan
+        args: --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan
   test_xcoder_logan:
     name: Test xcoder-logan
     runs-on:

--- a/ffmpeg/Cargo.toml
+++ b/ffmpeg/Cargo.toml
@@ -4,8 +4,15 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-ffmpeg-sys = {version = "4", git = "https://github.com/meh/rust-ffmpeg-sys", default-features = false, features = ["avcodec", "avformat"]}
+# XXX: ffmpeg-sys doesn't seem to build without avcodec.
+ffmpeg-sys = {version = "4", git = "https://github.com/meh/rust-ffmpeg-sys", default-features = false, features = ["avcodec"] }
 thiserror = "1.0"
+
+[features]
+avcodec = ["ffmpeg-sys/avcodec"]
+avfilter = ["ffmpeg-sys/avfilter"]
+avformat = ["ffmpeg-sys/avformat"]
+swscale = ["ffmpeg-sys/swscale"]
 
 [dev-dependencies]
 trybuild = "1.0"

--- a/ffmpeg/src/avformat/avio.rs
+++ b/ffmpeg/src/avformat/avio.rs
@@ -4,6 +4,7 @@ use std::{
     mem,
     os::raw::{c_int, c_void},
 };
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Error {

--- a/ffmpeg/src/lib.rs
+++ b/ffmpeg/src/lib.rs
@@ -1,6 +1,4 @@
-#[macro_use]
-extern crate thiserror;
-
+#[cfg(feature = "avformat")]
 pub mod avformat;
 pub mod avutil;
 

--- a/rfc6381/Cargo.toml
+++ b/rfc6381/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2018"
 
 [features]
 default = []
-ffmpeg = ["ffmpeg-sys"]
+ffmpeg = ["dep:ffmpeg"]
 
 [dependencies]
 h264 = { path = "../h264" }
 h265 = { path = "../h265" }
-ffmpeg-sys = {version = "4.0.2", git = "https://github.com/meh/rust-ffmpeg-sys", default-features = false, features = ["avcodec"], optional = true}
+ffmpeg = { path = "../ffmpeg", features = ["avcodec"], optional = true }

--- a/rfc6381/src/lib.rs
+++ b/rfc6381/src/lib.rs
@@ -52,8 +52,8 @@ pub fn codec_from_h265_nalu<T: Iterator<Item = u8>>(mut nalu: h265::NALUnit<h265
 }
 
 #[cfg(feature = "ffmpeg")]
-pub fn codec_from_ffmpeg_codec_context(codec: &ffmpeg_sys::AVCodecContext) -> Option<String> {
-    use ffmpeg_sys::*;
+pub fn codec_from_ffmpeg_codec_context(codec: &ffmpeg::sys::AVCodecContext) -> Option<String> {
+    use ffmpeg::sys::AVCodecID;
     match codec.codec_id {
         AVCodecID::AV_CODEC_ID_AAC => Some(format!("mp4a.40.{}", codec.profile + 1)),
         AVCodecID::AV_CODEC_ID_H264 => {


### PR DESCRIPTION
This will allow us to drop the direct `ffmpeg-sys` deps from callers.