### PR TITLE
xilinx large packet segfault protection

### DIFF
--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -183,8 +183,8 @@ mod encoder_tests {
                     }
                 }
                 Err(e) => match e.err {
-                    XlnxErrorType::XlnxSendMoreData => {}
-                    XlnxErrorType::XlnxTryAgain => {}
+                    XlnxErrorType::SendMoreData => {}
+                    XlnxErrorType::TryAgain => {}
                     _ => panic!("encoder processing has failed with error {:?}", e),
                 },
             }
@@ -205,8 +205,8 @@ mod encoder_tests {
                     break;
                 } // if flush was successful the first time, break
                 Err(e) => match e.err {
-                    XlnxErrorType::XlnxFlushAgain => {}
-                    XlnxErrorType::XlnxEOS => break,
+                    XlnxErrorType::FlushAgain => {}
+                    XlnxErrorType::EOS => break,
                     _ => panic!("error sending flush frame to encoder {:?}", e),
                 },
             }
@@ -221,8 +221,8 @@ mod encoder_tests {
                     processed_frame_count += 1;
                 }
                 Err(e) => match e.err {
-                    XlnxErrorType::XlnxEOS => break, //we have hit the end of the stream,
-                    XlnxErrorType::XlnxTryAgain => {}
+                    XlnxErrorType::EOS => break, //we have hit the end of the stream,
+                    XlnxErrorType::TryAgain => {}
                     _ => panic!("error receiving frame while flushing {:?}", e),
                 },
             }

--- a/xilinx/src/xlnx_error.rs
+++ b/xilinx/src/xlnx_error.rs
@@ -3,14 +3,16 @@ use std::fmt;
 
 use crate::XMA_TRY_AGAIN;
 
-#[derive(Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
 pub enum XlnxErrorType {
-    XlnxTryAgain,
-    XlnxEOS,
-    XlnxErr,
-    XlnxSendMoreData,
-    XlnxFlushAgain,
+    TryAgain,
+    EOS,
+    SendMoreData,
+    FlushAgain,
+    ErrorInvalid,
+    Other,
 }
+
 pub struct XlnxError {
     pub err: XlnxErrorType,
     pub message: String,
@@ -22,13 +24,15 @@ impl XlnxError {
         const EOS: i32 = XMA_EOS as i32;
         const SEND_MORE_DATA: i32 = XMA_SEND_MORE_DATA as i32;
         const FLUSH_AGAIN: i32 = XMA_FLUSH_AGAIN as i32;
+        const ERROR_INVALID: i32 = XMA_ERROR_INVALID as i32;
 
         let err = match xma_error {
-            TRY_AGAIN => XlnxErrorType::XlnxTryAgain,
-            EOS => XlnxErrorType::XlnxEOS,
-            SEND_MORE_DATA => XlnxErrorType::XlnxSendMoreData,
-            FLUSH_AGAIN => XlnxErrorType::XlnxFlushAgain,
-            _ => XlnxErrorType::XlnxErr,
+            TRY_AGAIN => XlnxErrorType::TryAgain,
+            EOS => XlnxErrorType::EOS,
+            SEND_MORE_DATA => XlnxErrorType::SendMoreData,
+            FLUSH_AGAIN => XlnxErrorType::FlushAgain,
+            ERROR_INVALID => XlnxErrorType::ErrorInvalid,
+            _ => XlnxErrorType::Other,
         };
 
         let message = match message {

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -83,7 +83,7 @@ impl XlnxScaler {
                 self.recv_frame()?;
             }
             Err(e) => match e.err {
-                XlnxErrorType::XlnxFlushAgain => {
+                XlnxErrorType::FlushAgain => {
                     self.recv_frame()?;
                 }
                 _ => return Err(e),
@@ -175,7 +175,7 @@ mod scaler_tests {
                     }
                 }
                 Err(e) => match e.err {
-                    XlnxErrorType::XlnxSendMoreData => {}
+                    XlnxErrorType::SendMoreData => {}
                     _ => panic!("scalar processing has failed with error {:?}", e),
                 },
             };
@@ -207,8 +207,8 @@ mod scaler_tests {
                         }
                     }
                     Err(e) => match e.err {
-                        XlnxErrorType::XlnxEOS => break,
-                        XlnxErrorType::XlnxFlushAgain => {}
+                        XlnxErrorType::EOS => break,
+                        XlnxErrorType::FlushAgain => {}
                         _ => panic!("error receiving flushing xilinx scaler: {:?}", e),
                     },
                 }


### PR DESCRIPTION
If you give the Xilinx decoder a packet with even 1 byte more than the number frame pixels, it either segfaults or errors out with "xma_plg_buffer_write failed. Can not write past end of buffer".

This adds a check to make sure it doesn't segfault.

I hate this change because it means any processed video absolutely _must_ have a certain compression ratio. But it's an improvement over segfaulting I guess.