### PR TITLE
fix forced key frames for netint logan 3.1.0 encoders

### DIFF
--- a/xcoder/xcoder-logan/src/encoder/xcoder_310.rs
+++ b/xcoder/xcoder-logan/src/encoder/xcoder_310.rs
@@ -307,7 +307,7 @@ impl<F: RawVideoFrame<u8>> XcoderEncoder<F> {
             frame.dts = frame.pts;
             if force_key_frame {
                 frame.force_key_frame = 1;
-                frame.ni_logan_pict_type = sys::ni_logan_pic_type_t_LOGAN_PIC_TYPE_IDR;
+                frame.ni_logan_pict_type = sys::ni_logan_pic_type_t_LOGAN_PIC_TYPE_FORCE_IDR;
             } else {
                 frame.force_key_frame = 0;
                 frame.ni_logan_pict_type = 0;


### PR DESCRIPTION
NETINT made a sneaky change: In the 3.1.0 API, unlike the 2.X API, you can't use the "IDR" pict type to force a key frame. You have to use "FORCE_IDR". This fixes it and adds a test.