### PR TITLE
use macos-11

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15]
+        os: [ubuntu-18.04, macos-11]
     steps:
     - uses: actions/checkout@v1
     - name: Set Up Linux


### PR DESCRIPTION
CI is starting to fail because GitHub is retiring macos-10.15 runners.