### PR TITLE
fix for macos usize / u64 type mismatches

### DIFF
--- a/macos/core-media/build.rs
+++ b/macos/core-media/build.rs
@@ -19,6 +19,8 @@ fn main() {
             .whitelist_function("CMSampleBuffer.+")
             .whitelist_var("kCFAllocator.+")
             .whitelist_var("kCMVideoCodecType_.+")
+            // See: https://github.com/rust-lang/rust-bindgen/issues/1671
+            .size_t_is_usize(true)
             .generate()
             .expect("unable to generate bindings");
 

--- a/macos/core-media/src/format_description.rs
+++ b/macos/core-media/src/format_description.rs
@@ -74,7 +74,7 @@ impl VideoFormatDescription {
         unsafe {
             let mut ret = std::ptr::null();
             let pointers: Vec<_> = parameter_sets.iter().map(|&ps| ps.as_ptr()).collect();
-            let sizes: Vec<_> = parameter_sets.iter().map(|ps| ps.len() as u64).collect();
+            let sizes: Vec<_> = parameter_sets.iter().map(|ps| ps.len()).collect();
             result(
                 sys::CMVideoFormatDescriptionCreateFromH264ParameterSets(
                     std::ptr::null_mut(),

--- a/macos/core-media/src/sample_buffer.rs
+++ b/macos/core-media/src/sample_buffer.rs
@@ -12,7 +12,7 @@ impl SampleBuffer {
         sample_sizes: Option<&[usize]>,
     ) -> Result<Self, OSStatus> {
         let mut ret = std::ptr::null_mut();
-        let sample_sizes = sample_sizes.map(|v| v.iter().map(|&ss| ss).collect::<Vec<_>>());
+        let sample_sizes = sample_sizes.map(|v| v.iter().copied().collect::<Vec<_>>());
         result(
             unsafe {
                 sys::CMSampleBufferCreate(

--- a/macos/core-media/src/sample_buffer.rs
+++ b/macos/core-media/src/sample_buffer.rs
@@ -12,7 +12,7 @@ impl SampleBuffer {
         sample_sizes: Option<&[usize]>,
     ) -> Result<Self, OSStatus> {
         let mut ret = std::ptr::null_mut();
-        let sample_sizes = sample_sizes.map(|v| v.iter().map(|&ss| ss as u64).collect::<Vec<_>>());
+        let sample_sizes = sample_sizes.map(|v| v.iter().map(|&ss| ss).collect::<Vec<_>>());
         result(
             unsafe {
                 sys::CMSampleBufferCreate(

--- a/macos/core-media/src/sample_buffer.rs
+++ b/macos/core-media/src/sample_buffer.rs
@@ -12,7 +12,6 @@ impl SampleBuffer {
         sample_sizes: Option<&[usize]>,
     ) -> Result<Self, OSStatus> {
         let mut ret = std::ptr::null_mut();
-        let sample_sizes = sample_sizes.map(|v| v.iter().copied().collect::<Vec<_>>());
         result(
             unsafe {
                 sys::CMSampleBufferCreate(

--- a/macos/core-video/build.rs
+++ b/macos/core-video/build.rs
@@ -17,6 +17,8 @@ fn main() {
             .whitelist_function("CVImageBuffer.+")
             .whitelist_function("CVPixelBuffer.+")
             .whitelist_var("kCVPixelBufferLock_ReadOnly")
+            // See: https://github.com/rust-lang/rust-bindgen/issues/1671
+            .size_t_is_usize(true)
             .generate()
             .expect("unable to generate bindings");
 

--- a/macos/core-video/src/pixel_buffer.rs
+++ b/macos/core-video/src/pixel_buffer.rs
@@ -1,7 +1,6 @@
 use super::{sys, ImageBuffer};
 use core_foundation::{result, CFType, OSStatus};
 use std::ffi::c_void;
-use sys::size_t;
 
 pub struct PixelBuffer(sys::CVPixelBufferRef);
 core_foundation::trait_impls!(PixelBuffer);
@@ -28,9 +27,9 @@ impl PixelBuffer {
         let mut plane_bytes_per_row = vec![];
         for p in planes.into_iter() {
             plane_ptrs.push(p.data as *mut c_void);
-            plane_widths.push(p.width as size_t);
-            plane_heights.push(p.height as size_t);
-            plane_bytes_per_row.push(p.bytes_per_row as size_t);
+            plane_widths.push(p.width as usize);
+            plane_heights.push(p.height as usize);
+            plane_bytes_per_row.push(p.bytes_per_row as usize);
         }
 
         let mut ret = std::ptr::null_mut();
@@ -61,11 +60,11 @@ impl PixelBuffer {
         unsafe { sys::CVPixelBufferGetPixelFormatType(self.0) }
     }
 
-    pub fn width(&self) -> size_t {
+    pub fn width(&self) -> usize {
         unsafe { sys::CVPixelBufferGetWidth(self.0) }
     }
 
-    pub fn height(&self) -> size_t {
+    pub fn height(&self) -> usize {
         unsafe { sys::CVPixelBufferGetHeight(self.0) }
     }
 

--- a/macos/core-video/src/pixel_buffer.rs
+++ b/macos/core-video/src/pixel_buffer.rs
@@ -1,6 +1,7 @@
 use super::{sys, ImageBuffer};
 use core_foundation::{result, CFType, OSStatus};
 use std::ffi::c_void;
+use sys::size_t;
 
 pub struct PixelBuffer(sys::CVPixelBufferRef);
 core_foundation::trait_impls!(PixelBuffer);
@@ -27,9 +28,9 @@ impl PixelBuffer {
         let mut plane_bytes_per_row = vec![];
         for p in planes.into_iter() {
             plane_ptrs.push(p.data as *mut c_void);
-            plane_widths.push(p.width as u64);
-            plane_heights.push(p.height as u64);
-            plane_bytes_per_row.push(p.bytes_per_row as u64);
+            plane_widths.push(p.width as size_t);
+            plane_heights.push(p.height as size_t);
+            plane_bytes_per_row.push(p.bytes_per_row as size_t);
         }
 
         let mut ret = std::ptr::null_mut();
@@ -60,11 +61,11 @@ impl PixelBuffer {
         unsafe { sys::CVPixelBufferGetPixelFormatType(self.0) }
     }
 
-    pub fn width(&self) -> u64 {
+    pub fn width(&self) -> size_t {
         unsafe { sys::CVPixelBufferGetWidth(self.0) }
     }
 
-    pub fn height(&self) -> u64 {
+    pub fn height(&self) -> size_t {
         unsafe { sys::CVPixelBufferGetHeight(self.0) }
     }
 


### PR DESCRIPTION
CI started failing due to a change in bindgen's default behavior:

https://github.com/sportsball-ai/av-rs/actions/runs/3266023301/jobs/5369153804


https://github.com/rust-lang/rust-bindgen/issues/1671

This fixes things by explicitly calling `size_t_is_usize(true)` and using `usize` for widths and heights.