### PR TITLE
Ensure decoder xvbm buffer pools are freed before xma_frames

### DIFF
--- a/xilinx/src/xlnx_decoder.rs
+++ b/xilinx/src/xlnx_decoder.rs
@@ -133,6 +133,12 @@ impl Drop for XlnxDecoder {
                 xma_dec_session_destroy(self.dec_session);
             }
             if !self.out_frame.is_null() {
+                // when the decoder is dropped ensure that the xvbm_buffer_pool_entry has been freed
+                // there is no problem if xvbm_buffer_pool_entry_free is called more than once for
+                // an entry as long as the xframe exists
+                let handle: XvbmBufferHandle = (*self.out_frame).data[0].buffer;
+                xvbm_buffer_pool_entry_free(handle);
+
                 xma_frame_free(self.out_frame);
             }
         }


### PR DESCRIPTION
Some applications experienced a seg fault if the decoder was dropped due to an abnormal exit. This was caused by the xframe being freed while leaving the xvbm buffer pool entries hanging. The xma decoder plugin would then attempt to free the entries when the application terminated causing a seg fault. This ensures that the buffer pool entries are freed before the xframe and not left hanging, so the decoder plugin will not attempt to free them during cleanup.