### PR TITLE
eliminate logan symbol conflicts

### DIFF
--- a/xcoder/xcoder-logan/xcoder-logan-310-sys/src/header.h
+++ b/xcoder/xcoder-logan/xcoder-logan-310-sys/src/header.h
@@ -1,8 +1,10 @@
 #ifndef RS_HEADER
 #define RS_HEADER 1
-// In order to link against both 3.1.0 and 2.5.9, these symbols need names that don't conflict with 2.5.9 symbols.
+// In order to link against both 3.1.0 and 2.5.9 or Quadra, these symbols need names that don't conflict.
 #define ni_log ni_logan_log
+#define ni_log_default_callback ni_logan_log_default_callback
 #define ni_log_set_level ni_logan_log_set_level
+#define ni_log_set_callback ni_logan_log_set_callback
 #define ni_log_get_level ni_logan_log_get_level
 #define ff_to_ni_log_level ff_to_ni_logan_log_level
 #define remove_substring_pattern logan_remove_substring_pattern


### PR DESCRIPTION
When compiling for both Logan and Quadra, apparently there are two more symbols that conflict. This resolves that.