### PR TITLE
[AVS-681] fix HEVC encoding in high bitrate

### DIFF
--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -204,7 +204,7 @@ impl<F> XcoderEncoder<F> {
                         // This specifies the size of the VBV (CPB) buffer in milliseconds.
                         // The range of supported values of `vbvBufferSize` is 0, and 10 to 3000. For example 3000 should be set for 3 seconds.
                         // Given a particular bitrate value, the maximum value of vbvBufferSize without leading to insufficient resource error is not documented.
-                        // For each bitrate range, we maximize vbvBufferSize value that does not exceed the Quadra encoder's processing capacity by trail and error.
+                        // For each bitrate range, we maximize vbvBufferSize value that does not exceed the Quadra encoder's processing capacity by trial and error.
                         cfg_enc_params.rc.vbv_buffer_size = match bitrate {
                             0..=80_000_000 => 3000,
                             80_000_001..=120_000_000 => 2000,

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -203,8 +203,8 @@ impl<F> XcoderEncoder<F> {
                     if let Some(bitrate) = config.bitrate {
                         // This specifies the size of the VBV (CPB) buffer in milliseconds.
                         // The range of supported values of `vbvBufferSize` is 0, and 10 to 3000. For example 3000 should be set for 3 seconds.
-                        // The relationship between bitrate and vbvBufferSize is non-linear but unknown.
-                        // Given each bitrate range, we maximize the vbvBufferSize value while not exceeding the Quadra encoder's processing capacity.
+                        // Given a particular bitrate value, the maximum value of vbvBufferSize without leading to insufficient resource error is not documented.
+                        // For each bitrate range, we maximize vbvBufferSize value that does not exceed the Quadra encoder's processing capacity by trail and error.
                         cfg_enc_params.rc.vbv_buffer_size = match bitrate {
                             0..=80_000_000 => 3000,
                             80_000_001..=120_000_000 => 2000,

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -201,9 +201,14 @@ impl<F> XcoderEncoder<F> {
                         };
                     }
                     // Rate control needs to be changed to VBR mode to encode at a higher bitrate (>60mbps).
-                    if config.bitrate.filter(|bitrate| *bitrate > 60_000_000).is_some() {
-                        cfg_enc_params.rc.vbv_buffer_size = 0;
-                    }
+                    if let Some(bitrate) = config.bitrate {
+                        cfg_enc_params.rc.vbv_buffer_size = match bitrate {
+                            0..=80_000_000 => 3000,
+                            80_000_001..=120_000_000 => 2000,
+                            120_000_001..=240_000_000 => 1000,
+                            _ => 0,
+                        }
+                    };
                 }
             }
 

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -200,8 +200,11 @@ impl<F> XcoderEncoder<F> {
                             XcoderH265Profile::Main10 => 2,
                         };
                     }
-                    // Rate control needs to be changed to VBR mode to encode at a higher bitrate (>60mbps).
                     if let Some(bitrate) = config.bitrate {
+                        // This specifies the size of the VBV (CPB) buffer in milliseconds.
+                        // The range of supported values of `vbvBufferSize` is 0, and 10 to 3000. For example 3000 should be set for 3 seconds.
+                        // The relationship between bitrate and vbvBufferSize is non-linear but unknown.
+                        // Given each bitrate range, we maximize the vbvBufferSize value while not exceeding the Quadra encoder's processing capacity.
                         cfg_enc_params.rc.vbv_buffer_size = match bitrate {
                             0..=80_000_000 => 3000,
                             80_000_001..=120_000_000 => 2000,

--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -200,6 +200,10 @@ impl<F> XcoderEncoder<F> {
                             XcoderH265Profile::Main10 => 2,
                         };
                     }
+                    // Rate control needs to be changed to VBR mode to encode at a higher bitrate (>60mbps).
+                    if config.bitrate.filter(|bitrate| *bitrate > 60_000_000).is_some() {
+                        cfg_enc_params.rc.vbv_buffer_size = 0;
+                    }
                 }
             }
 


### PR DESCRIPTION
Before the HEVC encoding using Quadra hardware would either fail with insufficient resource error for bitrate>80mbps or result in unexpected transcoded bitrate for 70mbps<bitrate<80mbps. This will allow us to encode at a higher bitrate (maximum 800mbps) using Quadra hardware.