### PR TITLE
fix SRT async write

### DIFF
--- a/srt/src/async_lib.rs
+++ b/srt/src/async_lib.rs
@@ -289,7 +289,7 @@ mod test {
         let mut server_conn = accept_result.unwrap().0;
         let mut client_conn = connect_result.unwrap();
         assert_eq!(client_conn.id(), None);
-        assert_eq!(client_conn.payload_size(), 1316);
+        assert_eq!(client_conn.payload_size, 1316);
 
         let mut buf = [0; 1316];
         for i in 0..5 {

--- a/srt/src/async_lib.rs
+++ b/srt/src/async_lib.rs
@@ -125,7 +125,9 @@ impl AsyncStream {
     fn new(id: Option<String>, socket: Socket) -> Result<Self> {
         socket.set(sys::SRT_SOCKOPT_SRTO_SNDSYN, false)?;
         socket.set(sys::SRT_SOCKOPT_SRTO_RCVSYN, false)?;
-        let max_send_payload_size = socket.get::<i32>(sys::SRT_SOCKOPT_SRTO_PAYLOADSIZE).unwrap_or(DEFAULT_SEND_PAYLOAD_SIZE as _) as _;
+        let max_send_payload_size = socket
+            .get::<i32>(sys::SRT_SOCKOPT_SRTO_PAYLOADSIZE)
+            .expect("SRT should have a default payload size if not set") as _;
         Ok(Self {
             epoll_reactor: socket.api.get_epoll_reactor()?,
             socket,

--- a/srt/src/async_lib.rs
+++ b/srt/src/async_lib.rs
@@ -3,7 +3,6 @@ use super::{
     epoll_reactor::{EpollReactor, READ_EVENTS, WRITE_EVENTS},
     listener_callback, new_io_error, sockaddr_from_storage, sys, to_sockaddr, ConnectOptions, Error, ListenerCallback, ListenerOption, Result, Socket,
 };
-use crate::DEFAULT_SEND_PAYLOAD_SIZE;
 use std::{
     future::Future,
     io, mem,

--- a/srt/src/async_lib.rs
+++ b/srt/src/async_lib.rs
@@ -159,6 +159,10 @@ impl AsyncStream {
     pub fn raw_stats(&mut self, clear: bool, instantaneous: bool) -> Result<sys::SRT_TRACEBSTATS> {
         self.socket.raw_stats(clear, instantaneous)
     }
+
+    pub fn payload_size(&self) -> usize {
+       self.payload_size
+    }
 }
 
 struct Connect {
@@ -289,6 +293,7 @@ mod test {
         let mut server_conn = accept_result.unwrap().0;
         let mut client_conn = connect_result.unwrap();
         assert_eq!(client_conn.id(), None);
+        assert_eq!(client_conn.payload_size(), 1316);
 
         let mut buf = [0; 1316];
         for i in 0..5 {

--- a/srt/src/lib.rs
+++ b/srt/src/lib.rs
@@ -606,6 +606,7 @@ mod test {
 
         options.passphrase = Some("thepassphrase".to_string());
         let mut conn = Stream::connect("127.0.0.1:1236", &options).unwrap();
+        assert_eq!(conn.write(b"foo").unwrap(), 3);
         let buf = [0; 2000];
         assert_eq!(conn.write(&buf[..]).unwrap(), 1400);
         assert_eq!(conn.id(), options.stream_id.as_ref());


### PR DESCRIPTION
This fixes SRT AsyncStream `poll_write`, so that it can accept data larger than SRT allowed payload size in UDP packets.