### PR TITLE
time creation using CMTimeMake function

### DIFF
--- a/macos/video-toolbox/build.rs
+++ b/macos/video-toolbox/build.rs
@@ -16,6 +16,7 @@ fn main() {
             .allowlist_function("VTCopyVideoEncoderList")
             .allowlist_function("VTDecompressionSession.+")
             .allowlist_function("VTSessionSetProperty")
+            .allowlist_function("CMTimeMake.*")
             .allowlist_var("kCMTime.+")
             .allowlist_var("kCVPixelFormatType_.+")
             .allowlist_var("kCMSampleAttachmentKey_.+")

--- a/macos/video-toolbox/src/compression_session.rs
+++ b/macos/video-toolbox/src/compression_session.rs
@@ -205,9 +205,9 @@ mod test {
     #[test]
     fn test_create_cm_time() {
         let time = unsafe { sys::CMTimeMake(20, 1000) };
-        assert_eq!(time.value as i64, 20);
-        assert_eq!(time.timescale as i32, 1000);
+        assert_eq!({ time.value }, 20);
+        assert_eq!({ time.timescale }, 1000);
         assert_eq!(time.flags, sys::kCMTimeFlags_Valid);
-        assert_eq!(time.epoch as i64, 0);
+        assert_eq!({ time.epoch }, 0);
     }
 }

--- a/macos/video-toolbox/src/video_encoder.rs
+++ b/macos/video-toolbox/src/video_encoder.rs
@@ -1,7 +1,8 @@
 use super::*;
+use crate::sys::CMTimeMake;
 use av_traits::{EncodedFrameType, EncodedVideoFrame, RawVideoFrame, VideoEncoderOutput};
 use core_foundation::{self as cf, Array, Boolean, CFType, Dictionary, MutableDictionary, Number, OSStatus};
-use core_media::{Time, VideoCodecType};
+use core_media::VideoCodecType;
 use core_video::{PixelBuffer, PixelBufferPlane};
 use std::pin::Pin;
 
@@ -365,8 +366,8 @@ impl<F: RawVideoFrame<u8> + Send + Unpin> av_traits::VideoEncoder for VideoEncod
 
         let frame_number = self.frame_count;
         self.frame_count += 1;
-        self.sess
-            .encode_frame(pixel_buffer.into(), Time::new((fps_den * frame_number) as _, fps_num as _), input, frame_type)?;
+        let presentation_time = unsafe { CMTimeMake((fps_den * frame_number) as _, fps_num as _) };
+        self.sess.encode_frame(pixel_buffer.into(), presentation_time, input, frame_type)?;
         self.next_video_encoder_trait_frame()
     }
 


### PR DESCRIPTION
The `flags` is set to be `0` in `CMTime` variables, which seems to be invalid. 
This uses a Core Media API `CMTimeMake` to create variables of `CMTime` type.