### PR TITLE
impl std::error::Error for XlnxError

### DIFF
--- a/xilinx/src/xlnx_error.rs
+++ b/xilinx/src/xlnx_error.rs
@@ -18,6 +18,8 @@ pub struct XlnxError {
     pub message: String,
 }
 
+impl std::error::Error for XlnxError {}
+
 impl XlnxError {
     pub fn new(xma_error: i32, message: Option<String>) -> Self {
         const TRY_AGAIN: i32 = XMA_TRY_AGAIN as i32;


### PR DESCRIPTION
We need impl `std::error::Error` for `XlnxError`, so that it can be downcasted from `Box<dyn std::error::Error>`.