### PR TITLE
vendored openssl should disable openssl pkg-config

### DIFF
--- a/srt/srt-sys/build.rs
+++ b/srt/srt-sys/build.rs
@@ -13,6 +13,7 @@ fn main() {
                 arch => arch,
             },
         );
+        build.define("USE_OPENSSL_PC", "OFF");
         build.define("OPENSSL_INCLUDE_DIR", format!("{}/vendor/openssl/include", env!("CARGO_MANIFEST_DIR")));
         build.define(
             "OPENSSL_CRYPTO_LIBRARY",


### PR DESCRIPTION
I saw strange/inconsistent behavior when compiling a dependent project. It was picking up homebrew-installed openssl@3 and failing on the lack of `openssl/evp.h`. After a `cargo clean`, I can't seem to reproduce. Still, it doesn't make sense to use both vendored openssl and look for another openssl via pkg-config, so let's not do that.

I compiled both `srt` itself and a dependent project after `cargo clean` in a few configs:

* no change => success (huh)
* this change only => success
* `CMakeLists.txt` hack below only => fail
* this change + `CMakeLists.txt` hack => succeeds

The hack to check that the `USE_OPENSSL_PC` define is making it through:

```
diff --git a/srt/srt-sys/vendor/srt-1.4.4/CMakeLists.txt b/srt/srt-sys/vendor/srt-1.4.4/CMakeLists.txt
index 21478c3..357f2b5 100644
--- a/srt/srt-sys/vendor/srt-1.4.4/CMakeLists.txt
+++ b/srt/srt-sys/vendor/srt-1.4.4/CMakeLists.txt
@@ -339,7 +339,7 @@ if (ENABLE_ENCRYPTION)
                # Try using pkg-config method first if enabled,
                # fall back to find_package method otherwise
                if (USE_OPENSSL_PC)
-                       pkg_check_modules(SSL ${SSL_REQUIRED_MODULES})
+                       message(FATAL_ERROR "openssl pc should be disabled")
                endif()
                if (SSL_FOUND)
                        # We have some cases when pkg-config is improperly configured
```