### PR TITLE
some Video Toolbox session tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1703,7 +1703,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf9cf6a813d3f40c88b0b6b6f29a5c95c6cdbf97c1f9cc53fb820200f5ad814d"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.15",
 ]
 
 [[package]]
@@ -1809,6 +1821,7 @@ dependencies = [
  "core-video",
  "h264",
  "textwrap 0.16.0",
+ "tracing",
 ]
 
 [[package]]

--- a/macos/video-toolbox/Cargo.toml
+++ b/macos/video-toolbox/Cargo.toml
@@ -13,6 +13,7 @@ av-traits = { path = "../../av-traits" }
 core-foundation = { path = "../core-foundation" }
 core-media = { path = "../core-media" }
 core-video = { path = "../core-video" }
+tracing = "0.1.37"
 
 [dev-dependencies]
 h264 = { path = "../../h264" }

--- a/macos/video-toolbox/build.rs
+++ b/macos/video-toolbox/build.rs
@@ -15,6 +15,7 @@ fn main() {
             .allowlist_function("VTCopySupportedPropertyDictionaryForEncoder")
             .allowlist_function("VTCopyVideoEncoderList")
             .allowlist_function("VTDecompressionSession.+")
+            .allowlist_function("VTSessionCopySupportedPropertyDictionary")
             .allowlist_function("VTSessionSetProperty")
             .allowlist_var("kCMTime.+")
             .allowlist_var("kCVPixelFormatType_.+")


### PR DESCRIPTION
It's occasionally helpful to have a final verification that the expected properties are being set. It's quite verbose, so only do it when the tracing level is cranked up all the way.