### PR TITLE
require srt callbacks be `Send` and `Sync`

### DIFF
--- a/srt/src/lib.rs
+++ b/srt/src/lib.rs
@@ -342,11 +342,11 @@ fn to_sockaddr(addr: &SocketAddr) -> (sys::sockaddr_storage, sys::socklen_t) {
     (storage, socklen as _)
 }
 
-pub trait ListenerCallback {
+pub trait ListenerCallback: Send + Sync {
     fn callback(&self, stream_id: Option<&str>) -> ListenerCallbackAction;
 }
 
-impl<T: Fn(Option<&str>) -> ListenerCallbackAction> ListenerCallback for T {
+impl<T: Fn(Option<&str>) -> ListenerCallbackAction + Send + Sync> ListenerCallback for T {
     fn callback(&self, stream_id: Option<&str>) -> ListenerCallbackAction {
         (*self)(stream_id)
     }


### PR DESCRIPTION
The `Send` reflects the reality that the SRT code internally passes these to its listener thread and runs there. Using a non-`Send` callback would be unsound!

I also added the `Sync` bound to allow the `AsyncListener` to be `Sync`. I believe this isn't strictly necessary: conceptually the ownership is handed to the SRT listener thread, then back later to run the destructor, so we could restructure `_callback`'s type a bit to be more permissive. But this is an easy way to solve the problem and seems harmless.