### PR TITLE
Separate Xilinx encoder loads

### DIFF
--- a/xilinx/src/xlnx_decoder.rs
+++ b/xilinx/src/xlnx_decoder.rs
@@ -173,16 +173,18 @@ mod decoder_tests {
 
         let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
 
-        let cu_list_res: xrmCuListResource = Default::default();
+        let cu_list_res: xrmCuListResourceV2 = Default::default();
 
         let mut xlnx_dec_ctx = XlnxDecoderXrmCtx {
-            xrm_reserve_id: 0,
-            device_id: -1,
+            xrm_reserve_id: None,
+            device_id: None,
             dec_load: xlnx_calc_dec_load(xrm_ctx, xma_dec_props.as_mut()).unwrap(),
             decode_res_in_use: false,
             xrm_ctx,
             cu_list_res,
         };
+
+        xlnx_reserve_dec_resource(&mut xlnx_dec_ctx).unwrap();
 
         // create Xlnx decoder
         let mut decoder = XlnxDecoder::new(xma_dec_props.as_mut(), &mut xlnx_dec_ctx).unwrap();
@@ -318,16 +320,18 @@ mod decoder_tests {
 
             let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
 
-            let cu_list_res: xrmCuListResource = Default::default();
+            let cu_list_res: xrmCuListResourceV2 = Default::default();
 
             let mut xlnx_dec_ctx = XlnxDecoderXrmCtx {
-                xrm_reserve_id: 0,
-                device_id: -1,
+                xrm_reserve_id: None,
+                device_id: None,
                 dec_load: xlnx_calc_dec_load(xrm_ctx, xma_dec_props.as_mut()).unwrap(),
                 decode_res_in_use: false,
                 xrm_ctx,
                 cu_list_res,
             };
+
+            xlnx_reserve_dec_resource(&mut xlnx_dec_ctx).unwrap();
 
             let mut decoder = XlnxDecoder::new(xma_dec_props.as_mut(), &mut xlnx_dec_ctx).unwrap();
 

--- a/xilinx/src/xlnx_decoder.rs
+++ b/xilinx/src/xlnx_decoder.rs
@@ -172,17 +172,8 @@ mod decoder_tests {
         let mut xma_dec_props = XlnxXmaDecoderProperties::from(dec_props);
 
         let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
-
-        let cu_list_res: xrmCuListResourceV2 = Default::default();
-
-        let mut xlnx_dec_ctx = XlnxDecoderXrmCtx {
-            xrm_reserve_id: None,
-            device_id: None,
-            dec_load: xlnx_calc_dec_load(xrm_ctx, xma_dec_props.as_mut()).unwrap(),
-            decode_res_in_use: false,
-            xrm_ctx,
-            cu_list_res,
-        };
+        let dec_load = xlnx_calc_dec_load(xrm_ctx, xma_dec_props.as_mut()).unwrap();
+        let mut xlnx_dec_ctx = XlnxDecoderXrmCtx::new(xrm_ctx, None, None, dec_load);
 
         xlnx_reserve_dec_resource(&mut xlnx_dec_ctx).unwrap();
 
@@ -319,17 +310,8 @@ mod decoder_tests {
             let mut xma_dec_props = XlnxXmaDecoderProperties::from(dec_props);
 
             let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
-
-            let cu_list_res: xrmCuListResourceV2 = Default::default();
-
-            let mut xlnx_dec_ctx = XlnxDecoderXrmCtx {
-                xrm_reserve_id: None,
-                device_id: None,
-                dec_load: xlnx_calc_dec_load(xrm_ctx, xma_dec_props.as_mut()).unwrap(),
-                decode_res_in_use: false,
-                xrm_ctx,
-                cu_list_res,
-            };
+            let dec_load = xlnx_calc_dec_load(xrm_ctx, xma_dec_props.as_mut()).unwrap();
+            let mut xlnx_dec_ctx = XlnxDecoderXrmCtx::new(xrm_ctx, None, None, dec_load);
 
             xlnx_reserve_dec_resource(&mut xlnx_dec_ctx).unwrap();
 

--- a/xilinx/src/xlnx_enc_utils.rs
+++ b/xilinx/src/xlnx_enc_utils.rs
@@ -6,12 +6,12 @@ use std::{ffi::CString, os::raw::c_char, str::from_utf8};
 const ENC_PLUGIN_NAME: &[u8] = b"xrmU30EncPlugin\0";
 
 pub struct XlnxEncoderXrmCtx {
-    pub xrm_reserve_id: u64,
-    pub device_id: i32,
+    pub xrm_reserve_id: Option<u64>,
+    pub device_id: Option<u64>,
     pub enc_load: i32,
     pub encode_res_in_use: bool,
     pub xrm_ctx: xrmContext,
-    pub cu_list_res: xrmCuListResource,
+    pub cu_list_res: xrmCuListResourceV2,
 }
 
 /// Calculates the encoder load uing the xrmU30Enc plugin.
@@ -58,15 +58,22 @@ pub fn xlnx_calc_enc_load(xrm_ctx: xrmContext, xma_enc_props: *mut XmaEncoderPro
     Ok(load)
 }
 
-fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolProperty, enc_count: i32, enc_load: i32) -> Result<(), SimpleError> {
-    cu_pool_prop.cuListProp.sameDevice = true;
+fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, enc_count: i32, enc_load: i32, device_id: Option<u64>) -> Result<(), SimpleError> {
     cu_pool_prop.cuListNum = 1;
     let mut cu_num = 0;
+    let mut device_info = 0;
+
+    if let Some(device_id) = device_id {
+        device_info = (device_id << XRM_DEVICE_INFO_DEVICE_INDEX_SHIFT)
+            | ((XRM_DEVICE_INFO_CONSTRAINT_TYPE_HARDWARE_DEVICE_INDEX as u64) << XRM_DEVICE_INFO_CONSTRAINT_TYPE_SHIFT);
+    }
 
     strcpy_to_arr_i8(&mut cu_pool_prop.cuListProp.cuProps[cu_num].kernelName, "encoder")?;
     strcpy_to_arr_i8(&mut cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "ENCODER_MPSOC")?;
     cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
     cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(enc_load);
+    cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
+
     cu_num += 1;
 
     for _ in 0..enc_count {
@@ -74,94 +81,41 @@ fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolProperty, enc_count: i32
 
         cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
+        cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
         cu_num += 1
     }
-    // we defined 2 cu requests to the properties.
+    // we defined multiple cu requests to the properties.
     cu_pool_prop.cuListProp.cuNum = cu_num as i32;
 
     Ok(())
 }
 
-pub fn xlnx_reserve_enc_resource(xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
-    // a device has already been chosen, there is no need to assign a reserve id.
-    if xlnx_enc_ctx.device_id >= 0 {
-        return Ok(());
-    }
-
+pub fn xlnx_reserve_enc_resource(xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<xrmCuPoolResInforV2, SimpleError> {
     let enc_count = 1;
-    let mut cu_pool_prop: xrmCuPoolProperty = Default::default();
-    xlnx_fill_enc_pool_props(&mut cu_pool_prop, enc_count, xlnx_enc_ctx.enc_load)?;
+    let mut cu_pool_prop: xrmCuPoolPropertyV2 = Default::default();
+    let mut cu_pool_res_infor: xrmCuPoolResInforV2 = Default::default();
+    xlnx_fill_enc_pool_props(&mut cu_pool_prop, enc_count, xlnx_enc_ctx.enc_load, xlnx_enc_ctx.device_id)?;
 
     unsafe {
-        let num_cu_pool = xrmCheckCuPoolAvailableNum(xlnx_enc_ctx.xrm_ctx, &mut cu_pool_prop);
+        let num_cu_pool = xrmCheckCuPoolAvailableNumV2(xlnx_enc_ctx.xrm_ctx, &mut cu_pool_prop);
         if num_cu_pool <= 0 {
             bail!("no encoder resources avaliable for allocation")
         }
 
-        xlnx_enc_ctx.xrm_reserve_id = xrmCuPoolReserve(xlnx_enc_ctx.xrm_ctx, &mut cu_pool_prop);
-        if xlnx_enc_ctx.xrm_reserve_id == 0 {
+        let xrm_reserve_id: u64 = xrmCuPoolReserveV2(xlnx_enc_ctx.xrm_ctx, &mut cu_pool_prop, &mut cu_pool_res_infor);
+        if xrm_reserve_id == 0 {
             bail!("failed to reserve encode cu pool")
         }
+        xlnx_enc_ctx.xrm_reserve_id = Some(xrm_reserve_id);
     }
 
-    Ok(())
+    Ok(cu_pool_res_infor)
 }
 
-/// Allocates encoder CU based on device_id
-fn xlnx_enc_cu_alloc_device_id(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
-    let mut encode_cu_hw_prop: xrmCuProperty = Default::default();
-    let mut encode_cu_sw_prop: xrmCuProperty = Default::default();
-
-    strcpy_to_arr_i8(&mut encode_cu_hw_prop.kernelName, "encoder")?;
-    strcpy_to_arr_i8(&mut encode_cu_hw_prop.kernelAlias, "ENCODER_MPSOC")?;
-    encode_cu_hw_prop.devExcl = false;
-    encode_cu_hw_prop.requestLoad = xrm_precision_1000000_bitmask(xlnx_enc_ctx.enc_load);
-
-    strcpy_to_arr_i8(&mut encode_cu_sw_prop.kernelName, "kernel_vcu_encoder")?;
-    encode_cu_sw_prop.devExcl = false;
-    encode_cu_sw_prop.requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
-
-    let ret = unsafe {
-        xrmCuAllocFromDev(
-            xlnx_enc_ctx.xrm_ctx,
-            xlnx_enc_ctx.device_id,
-            &mut encode_cu_hw_prop,
-            &mut xlnx_enc_ctx.cu_list_res.cuResources[0],
-        )
-    };
-    if ret <= XRM_ERROR {
-        bail!("xrm failed to allocate encoder resources on device: {}", xlnx_enc_ctx.device_id);
-    }
-
-    let ret = unsafe {
-        xrmCuAllocFromDev(
-            xlnx_enc_ctx.xrm_ctx,
-            xlnx_enc_ctx.device_id,
-            &mut encode_cu_sw_prop,
-            &mut xlnx_enc_ctx.cu_list_res.cuResources[1],
-        )
-    };
-    if ret <= XRM_ERROR {
-        bail!("xrm failed to allocate encoder resources on device: {}", xlnx_enc_ctx.device_id);
-    }
-    xlnx_enc_ctx.encode_res_in_use = true;
-
-    // Set XMA plugin shared object and device index.
-    xma_enc_props.plugin_lib = xlnx_enc_ctx.cu_list_res.cuResources[0].kernelPluginFileName.as_mut_ptr();
-    xma_enc_props.dev_index = xlnx_enc_ctx.cu_list_res.cuResources[0].deviceId;
-
-    // Select ddr bank based on xclbin metadata.
-    xma_enc_props.ddr_bank_index = -1;
-    xma_enc_props.cu_index = xlnx_enc_ctx.cu_list_res.cuResources[1].cuId;
-    xma_enc_props.channel_id = xlnx_enc_ctx.cu_list_res.cuResources[1].channelId;
-
-    Ok(())
-}
-
-/// Allocated encoder CU based on reserve_id
-fn xlnx_enc_cu_alloc_reserve_id(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
+/// Allocated encoder CU
+fn xlnx_enc_cu_alloc(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
     // Allocate xrm encoder cu
-    let mut encode_cu_list_prop = xrmCuListProperty {
+    let mut encode_cu_list_prop = xrmCuListPropertyV2 {
         cuNum: 2,
         ..Default::default()
     };
@@ -170,15 +124,44 @@ fn xlnx_enc_cu_alloc_reserve_id(xma_enc_props: &mut XmaEncoderProperties, xlnx_e
     strcpy_to_arr_i8(&mut encode_cu_list_prop.cuProps[0].kernelAlias, "ENCODER_MPSOC")?;
     encode_cu_list_prop.cuProps[0].devExcl = false;
     encode_cu_list_prop.cuProps[0].requestLoad = xrm_precision_1000000_bitmask(xlnx_enc_ctx.enc_load);
-    encode_cu_list_prop.cuProps[0].poolId = xlnx_enc_ctx.xrm_reserve_id;
 
     strcpy_to_arr_i8(&mut encode_cu_list_prop.cuProps[1].kernelName, "kernel_vcu_encoder")?;
     encode_cu_list_prop.cuProps[1].devExcl = false;
     encode_cu_list_prop.cuProps[1].requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
-    encode_cu_list_prop.cuProps[1].poolId = xlnx_enc_ctx.xrm_reserve_id;
 
-    if unsafe { xrmCuListAlloc(xlnx_enc_ctx.xrm_ctx, &mut encode_cu_list_prop, &mut xlnx_enc_ctx.cu_list_res) } != 0 {
-        bail!("failed to allocate encode cu list from reserve id {}", xlnx_enc_ctx.xrm_reserve_id)
+    match (xlnx_enc_ctx.device_id, xlnx_enc_ctx.xrm_reserve_id) {
+        (Some(device_id), Some(xrm_reserve_id)) => {
+            let device_info = (device_id << XRM_DEVICE_INFO_DEVICE_INDEX_SHIFT)
+                | ((XRM_DEVICE_INFO_CONSTRAINT_TYPE_HARDWARE_DEVICE_INDEX as u64) << XRM_DEVICE_INFO_CONSTRAINT_TYPE_SHIFT);
+            encode_cu_list_prop.cuProps[0].deviceInfo = device_info as _;
+            encode_cu_list_prop.cuProps[0].poolId = xrm_reserve_id;
+            encode_cu_list_prop.cuProps[1].deviceInfo = device_info as _;
+            encode_cu_list_prop.cuProps[1].poolId = xrm_reserve_id;
+        }
+        (Some(device_id), None) => {
+            let device_info = (device_id << XRM_DEVICE_INFO_DEVICE_INDEX_SHIFT)
+                | ((XRM_DEVICE_INFO_CONSTRAINT_TYPE_HARDWARE_DEVICE_INDEX as u64) << XRM_DEVICE_INFO_CONSTRAINT_TYPE_SHIFT);
+            encode_cu_list_prop.cuProps[0].deviceInfo = device_info as _;
+            encode_cu_list_prop.cuProps[1].deviceInfo = device_info as _;
+        }
+        (None, Some(reserve_id)) => {
+            encode_cu_list_prop.cuProps[0].poolId = reserve_id;
+            encode_cu_list_prop.cuProps[1].poolId = reserve_id;
+        }
+        (None, None) => {
+            // use the zero indexed device as the default if no device or reserve_id have been provided
+            let device_info = (XRM_DEVICE_INFO_CONSTRAINT_TYPE_HARDWARE_DEVICE_INDEX as u64) << XRM_DEVICE_INFO_CONSTRAINT_TYPE_SHIFT;
+            encode_cu_list_prop.cuProps[0].deviceInfo = device_info as _;
+            encode_cu_list_prop.cuProps[1].deviceInfo = device_info as _;
+        }
+    }
+
+    if unsafe { xrmCuListAllocV2(xlnx_enc_ctx.xrm_ctx, &mut encode_cu_list_prop, &mut xlnx_enc_ctx.cu_list_res) } != XRM_SUCCESS as _ {
+        bail!(
+            "failed to allocate encode cu list from reserve id {:?} and device id {:?}",
+            xlnx_enc_ctx.xrm_reserve_id,
+            xlnx_enc_ctx.device_id
+        );
     }
     xlnx_enc_ctx.encode_res_in_use = true;
 
@@ -190,17 +173,6 @@ fn xlnx_enc_cu_alloc_reserve_id(xma_enc_props: &mut XmaEncoderProperties, xlnx_e
     xma_enc_props.ddr_bank_index = -1;
     xma_enc_props.cu_index = xlnx_enc_ctx.cu_list_res.cuResources[1].cuId;
     xma_enc_props.channel_id = xlnx_enc_ctx.cu_list_res.cuResources[1].channelId;
-
-    Ok(())
-}
-
-fn xlnx_enc_cu_alloc(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
-    xlnx_enc_ctx.enc_load = xlnx_calc_enc_load(xlnx_enc_ctx.xrm_ctx, xma_enc_props)?;
-    if xlnx_enc_ctx.device_id >= 0 {
-        xlnx_enc_cu_alloc_device_id(xma_enc_props, xlnx_enc_ctx)?;
-    } else {
-        xlnx_enc_cu_alloc_reserve_id(xma_enc_props, xlnx_enc_ctx)?;
-    }
 
     Ok(())
 }
@@ -226,8 +198,11 @@ impl Drop for XlnxEncoderXrmCtx {
             return;
         }
         unsafe {
+            if let Some(xrm_reserve_id) = self.xrm_reserve_id {
+                let _ = xrmCuPoolRelinquishV2(self.xrm_ctx, xrm_reserve_id);
+            }
             if self.encode_res_in_use {
-                xrmCuListRelease(self.xrm_ctx, &mut self.cu_list_res);
+                let _ = xrmCuListReleaseV2(self.xrm_ctx, &mut self.cu_list_res);
             }
         }
     }

--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -154,17 +154,19 @@ mod encoder_tests {
 
         let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
 
-        let cu_list_res: xrmCuListResource = Default::default();
+        let cu_list_res: xrmCuListResourceV2 = Default::default();
         let enc_load = xlnx_calc_enc_load(xrm_ctx, xma_enc_props.as_mut()).unwrap();
 
         let mut xlnx_enc_ctx = XlnxEncoderXrmCtx {
-            xrm_reserve_id: 0,
-            device_id: -1,
+            xrm_reserve_id: None,
+            device_id: None,
             enc_load,
             encode_res_in_use: false,
             xrm_ctx,
             cu_list_res,
         };
+
+        xlnx_reserve_enc_resource(&mut xlnx_enc_ctx).unwrap();
 
         // create xlnx encoder
         let mut encoder = XlnxEncoder::new(xma_enc_props.as_mut(), &mut xlnx_enc_ctx).unwrap();

--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -153,18 +153,8 @@ mod encoder_tests {
         let mut xma_enc_props = XlnxXmaEncoderProperties::try_from(enc_props).unwrap();
 
         let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
-
-        let cu_list_res: xrmCuListResourceV2 = Default::default();
         let enc_load = xlnx_calc_enc_load(xrm_ctx, xma_enc_props.as_mut()).unwrap();
-
-        let mut xlnx_enc_ctx = XlnxEncoderXrmCtx {
-            xrm_reserve_id: None,
-            device_id: None,
-            enc_load,
-            encode_res_in_use: false,
-            xrm_ctx,
-            cu_list_res,
-        };
+        let mut xlnx_enc_ctx = XlnxEncoderXrmCtx::new(xrm_ctx, None, None, enc_load);
 
         xlnx_reserve_enc_resource(&mut xlnx_enc_ctx).unwrap();
 

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -28,7 +28,7 @@ impl XlnxScaler {
                     ..Default::default()
                 };
 
-                let mut xma_frame = xma_frame_alloc(&mut frame_props, true);
+                let xma_frame = xma_frame_alloc(&mut frame_props, true);
 
                 // Loop through the planes. no buffer shouold be allocated yet.
                 // Since this will be used in a pipeline, xvbm will allocate the buffers.
@@ -144,17 +144,19 @@ mod scaler_tests {
 
         let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
 
-        let cu_res: xrmCuResource = Default::default();
+        let cu_res: xrmCuResourceV2 = Default::default();
 
         let mut xlnx_scal_ctx = XlnxScalerXrmCtx {
-            xrm_reserve_id: 0,
-            device_id: -1,
+            xrm_reserve_id: None,
+            device_id: None,
             scal_load: xlnx_calc_scal_load(xrm_ctx, xma_scal_props.as_mut()).unwrap(),
             scal_res_in_use: false,
             xrm_ctx,
             num_outputs: 3,
             cu_res,
         };
+
+        xlnx_reserve_scal_resource(&mut xlnx_scal_ctx).unwrap();
 
         // create xlnx scaler
         let mut scaler = XlnxScaler::new(xma_scal_props.as_mut(), &mut xlnx_scal_ctx).unwrap();

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -143,18 +143,8 @@ mod scaler_tests {
         let mut xma_scal_props = XlnxXmaScalerProperties::from(scal_props);
 
         let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
-
-        let cu_res: xrmCuResourceV2 = Default::default();
-
-        let mut xlnx_scal_ctx = XlnxScalerXrmCtx {
-            xrm_reserve_id: None,
-            device_id: None,
-            scal_load: xlnx_calc_scal_load(xrm_ctx, xma_scal_props.as_mut()).unwrap(),
-            scal_res_in_use: false,
-            xrm_ctx,
-            num_outputs: 3,
-            cu_res,
-        };
+        let scal_load = xlnx_calc_scal_load(xrm_ctx, xma_scal_props.as_mut()).unwrap();
+        let mut xlnx_scal_ctx = XlnxScalerXrmCtx::new(xrm_ctx, None, None, scal_load, 3);
 
         xlnx_reserve_scal_resource(&mut xlnx_scal_ctx).unwrap();
 

--- a/xilinx/src/xlnx_transcoder_utils.rs
+++ b/xilinx/src/xlnx_transcoder_utils.rs
@@ -94,7 +94,11 @@ fn xlnx_fill_transcode_pool_props(
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelName, "encoder")?;
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "ENCODER_MPSOC")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
+<<<<<<< HEAD
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(total_enc_load);
+=======
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(transcode_load.enc_load);
+>>>>>>> 85e9b64 ([AVS-1020] Update to v2 allocation and reservation functions (#176))
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info;
         cu_num += 1;
 

--- a/xilinx/src/xlnx_transcoder_utils.rs
+++ b/xilinx/src/xlnx_transcoder_utils.rs
@@ -11,7 +11,8 @@ pub struct XlnxTranscodeLoad {
 pub struct XlnxTranscodeXrmCtx {
     pub xrm_ctx: xrmContext,
     pub transcode_load: XlnxTranscodeLoad,
-    pub reserve_idx: u64,
+    pub xrm_reserve_id: Option<u64>,
+    pub device_id: Option<u64>,
 }
 
 impl XlnxTranscodeXrmCtx {
@@ -26,7 +27,8 @@ impl XlnxTranscodeXrmCtx {
                 enc_load: 0,
                 enc_num: 0,
             },
-            reserve_idx: 0,
+            xrm_reserve_id: None,
+            device_id: None,
         }
     }
 }
@@ -36,7 +38,7 @@ pub fn xlnx_calc_transcode_load(
     xma_dec_props: &mut XmaDecoderProperties,
     xma_scal_props: &mut XmaScalerProperties,
     xma_enc_props_list: Vec<&mut XmaEncoderProperties>,
-    transcode_cu_pool_prop: &mut xrmCuPoolProperty,
+    transcode_cu_pool_prop: &mut xrmCuPoolPropertyV2,
 ) -> Result<(), SimpleError> {
     xlnx_transcode_xrm_ctx.transcode_load.dec_load = xlnx_calc_dec_load(xlnx_transcode_xrm_ctx.xrm_ctx, xma_dec_props)?;
     xlnx_transcode_xrm_ctx.transcode_load.scal_load = xlnx_calc_scal_load(xlnx_transcode_xrm_ctx.xrm_ctx, xma_scal_props)?;
@@ -45,25 +47,35 @@ pub fn xlnx_calc_transcode_load(
         xlnx_transcode_xrm_ctx.transcode_load.enc_num += 1;
     }
 
-    xlnx_fill_transcode_pool_props(transcode_cu_pool_prop, &xlnx_transcode_xrm_ctx.transcode_load)?;
+    xlnx_fill_transcode_pool_props(transcode_cu_pool_prop, &xlnx_transcode_xrm_ctx.transcode_load, xlnx_transcode_xrm_ctx.device_id)?;
     Ok(())
 }
 
-fn xlnx_fill_transcode_pool_props(transcode_cu_pool_prop: &mut xrmCuPoolProperty, transcode_load: &XlnxTranscodeLoad) -> Result<(), SimpleError> {
+fn xlnx_fill_transcode_pool_props(
+    transcode_cu_pool_prop: &mut xrmCuPoolPropertyV2,
+    transcode_load: &XlnxTranscodeLoad,
+    device_id: Option<u64>,
+) -> Result<(), SimpleError> {
     let mut cu_num = 0;
-    transcode_cu_pool_prop.cuListProp.sameDevice = true;
     transcode_cu_pool_prop.cuListNum = 1;
+    let mut device_info = 0;
+    if let Some(device_id) = device_id {
+        device_info = (device_id << XRM_DEVICE_INFO_DEVICE_INDEX_SHIFT)
+            | ((XRM_DEVICE_INFO_CONSTRAINT_TYPE_HARDWARE_DEVICE_INDEX as u64) << XRM_DEVICE_INFO_CONSTRAINT_TYPE_SHIFT);
+    }
 
     if transcode_load.dec_load > 0 {
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelName, "decoder")?;
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "DECODER_MPSOC")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(transcode_load.dec_load);
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
         cu_num += 1;
 
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelName, "kernel_vcu_decoder")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
         cu_num += 1;
     }
 
@@ -72,6 +84,7 @@ fn xlnx_fill_transcode_pool_props(transcode_cu_pool_prop: &mut xrmCuPoolProperty
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "SCALER_MPSOC")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(transcode_load.scal_load);
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
         cu_num += 1;
     }
 
@@ -80,6 +93,7 @@ fn xlnx_fill_transcode_pool_props(transcode_cu_pool_prop: &mut xrmCuPoolProperty
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "ENCODER_MPSOC")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(transcode_load.enc_load);
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
         cu_num += 1;
 
         for _ in 0..transcode_load.enc_num {
@@ -87,6 +101,7 @@ fn xlnx_fill_transcode_pool_props(transcode_cu_pool_prop: &mut xrmCuPoolProperty
             strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "")?;
             transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
             transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
+            transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
             cu_num += 1;
         }
     }
@@ -100,8 +115,9 @@ pub fn xlnx_reserve_transcode_resource(
     xma_dec_props: &mut XmaDecoderProperties,
     xma_scal_props: &mut XmaScalerProperties,
     xma_enc_props: Vec<&mut XmaEncoderProperties>,
-) -> Result<(), SimpleError> {
-    let mut transcode_cu_pool_prop: xrmCuPoolProperty = Default::default();
+) -> Result<xrmCuPoolResInforV2, SimpleError> {
+    let mut transcode_cu_pool_prop: xrmCuPoolPropertyV2 = Default::default();
+    let mut cu_pool_res_infor: xrmCuPoolResInforV2 = Default::default();
     xlnx_calc_transcode_load(
         xlnx_transcode_xrm_ctx,
         xma_dec_props,
@@ -110,17 +126,18 @@ pub fn xlnx_reserve_transcode_resource(
         &mut transcode_cu_pool_prop,
     )?;
     unsafe {
-        let num_cu_pool = xrmCheckCuPoolAvailableNum(xlnx_transcode_xrm_ctx.xrm_ctx, &mut transcode_cu_pool_prop);
+        let num_cu_pool = xrmCheckCuPoolAvailableNumV2(xlnx_transcode_xrm_ctx.xrm_ctx, &mut transcode_cu_pool_prop);
         if num_cu_pool <= 0 {
             bail!("no xilinx hardware resources avaliable for allocation")
         }
-        xlnx_transcode_xrm_ctx.reserve_idx = xrmCuPoolReserve(xlnx_transcode_xrm_ctx.xrm_ctx, &mut transcode_cu_pool_prop);
-        if xlnx_transcode_xrm_ctx.reserve_idx == 0 {
+        let xrm_reserve_id = xrmCuPoolReserveV2(xlnx_transcode_xrm_ctx.xrm_ctx, &mut transcode_cu_pool_prop, &mut cu_pool_res_infor);
+        if xrm_reserve_id == 0 {
             bail!("failed to reserve transcode cu pool")
         }
+        xlnx_transcode_xrm_ctx.xrm_reserve_id = Some(xrm_reserve_id);
     }
 
-    Ok(())
+    Ok(cu_pool_res_infor)
 }
 
 impl Default for XlnxTranscodeXrmCtx {
@@ -135,8 +152,8 @@ impl Drop for XlnxTranscodeXrmCtx {
             return;
         }
         unsafe {
-            if self.reserve_idx != 0 {
-                xrmCuPoolRelinquish(self.xrm_ctx, self.reserve_idx);
+            if let Some(xrm_reserve_id) = self.xrm_reserve_id {
+                let _ = xrmCuPoolRelinquishV2(self.xrm_ctx, xrm_reserve_id);
             }
 
             xrmDestroyContext(self.xrm_ctx);

--- a/xilinx/src/xlnx_transcoder_utils.rs
+++ b/xilinx/src/xlnx_transcoder_utils.rs
@@ -12,7 +12,7 @@ pub struct XlnxTranscodeXrmCtx {
     pub xrm_ctx: xrmContext,
     pub transcode_load: XlnxTranscodeLoad,
     pub xrm_reserve_id: Option<u64>,
-    pub device_id: Option<u64>,
+    pub device_id: Option<u32>,
 }
 
 impl XlnxTranscodeXrmCtx {
@@ -54,13 +54,13 @@ pub fn xlnx_calc_transcode_load(
 fn xlnx_fill_transcode_pool_props(
     transcode_cu_pool_prop: &mut xrmCuPoolPropertyV2,
     transcode_load: &XlnxTranscodeLoad,
-    device_id: Option<u64>,
+    device_id: Option<u32>,
 ) -> Result<(), SimpleError> {
     let mut cu_num = 0;
     transcode_cu_pool_prop.cuListNum = 1;
     let mut device_info = 0;
     if let Some(device_id) = device_id {
-        device_info = (device_id << XRM_DEVICE_INFO_DEVICE_INDEX_SHIFT)
+        device_info = (device_id << XRM_DEVICE_INFO_DEVICE_INDEX_SHIFT) as u64
             | ((XRM_DEVICE_INFO_CONSTRAINT_TYPE_HARDWARE_DEVICE_INDEX as u64) << XRM_DEVICE_INFO_CONSTRAINT_TYPE_SHIFT);
     }
 
@@ -69,13 +69,13 @@ fn xlnx_fill_transcode_pool_props(
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "DECODER_MPSOC")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(transcode_load.dec_load);
-        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info;
         cu_num += 1;
 
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelName, "kernel_vcu_decoder")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
-        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info;
         cu_num += 1;
     }
 
@@ -84,7 +84,7 @@ fn xlnx_fill_transcode_pool_props(
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "SCALER_MPSOC")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(transcode_load.scal_load);
-        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info;
         cu_num += 1;
     }
 
@@ -93,7 +93,7 @@ fn xlnx_fill_transcode_pool_props(
         strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "ENCODER_MPSOC")?;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
         transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(transcode_load.enc_load);
-        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
+        transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info;
         cu_num += 1;
 
         for _ in 0..transcode_load.enc_num {
@@ -101,7 +101,7 @@ fn xlnx_fill_transcode_pool_props(
             strcpy_to_arr_i8(&mut transcode_cu_pool_prop.cuListProp.cuProps[cu_num].kernelAlias, "")?;
             transcode_cu_pool_prop.cuListProp.cuProps[cu_num].devExcl = false;
             transcode_cu_pool_prop.cuListProp.cuProps[cu_num].requestLoad = xrm_precision_1000000_bitmask(XRM_MAX_CU_LOAD_GRANULARITY_1000000 as i32);
-            transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info as _;
+            transcode_cu_pool_prop.cuListProp.cuProps[cu_num].deviceInfo = device_info;
             cu_num += 1;
         }
     }

--- a/xilinx/src/xlnx_transcoder_utils.rs
+++ b/xilinx/src/xlnx_transcoder_utils.rs
@@ -115,9 +115,9 @@ pub fn xlnx_reserve_transcode_resource(
     xma_dec_props: &mut XmaDecoderProperties,
     xma_scal_props: &mut XmaScalerProperties,
     xma_enc_props: Vec<&mut XmaEncoderProperties>,
-) -> Result<xrmCuPoolResInforV2, SimpleError> {
-    let mut transcode_cu_pool_prop: xrmCuPoolPropertyV2 = Default::default();
-    let mut cu_pool_res_infor: xrmCuPoolResInforV2 = Default::default();
+) -> Result<Box<xrmCuPoolResInforV2>, SimpleError> {
+    let mut transcode_cu_pool_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
+    let mut cu_pool_res_infor: Box<xrmCuPoolResInforV2> = Box::new(Default::default());
     xlnx_calc_transcode_load(
         xlnx_transcode_xrm_ctx,
         xma_dec_props,
@@ -126,11 +126,11 @@ pub fn xlnx_reserve_transcode_resource(
         &mut transcode_cu_pool_prop,
     )?;
     unsafe {
-        let num_cu_pool = xrmCheckCuPoolAvailableNumV2(xlnx_transcode_xrm_ctx.xrm_ctx, &mut transcode_cu_pool_prop);
+        let num_cu_pool = xrmCheckCuPoolAvailableNumV2(xlnx_transcode_xrm_ctx.xrm_ctx, transcode_cu_pool_prop.as_mut());
         if num_cu_pool <= 0 {
             bail!("no xilinx hardware resources avaliable for allocation")
         }
-        let xrm_reserve_id = xrmCuPoolReserveV2(xlnx_transcode_xrm_ctx.xrm_ctx, &mut transcode_cu_pool_prop, &mut cu_pool_res_infor);
+        let xrm_reserve_id = xrmCuPoolReserveV2(xlnx_transcode_xrm_ctx.xrm_ctx, transcode_cu_pool_prop.as_mut(), cu_pool_res_infor.as_mut());
         if xrm_reserve_id == 0 {
             bail!("failed to reserve transcode cu pool")
         }


### PR DESCRIPTION
To make allocating encoders work correctly, store the individual enc loads instead of summing them.