### PR TITLE
run actions on `macos-12-large`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-11]
+        os: [ubuntu-latest, macos-12-large]
     steps:
     - uses: actions/checkout@v1
     - name: Set Up Linux


### PR DESCRIPTION
This should be considerably faster:

* homebrew appears to now build everything from scratch on macos 11 and shouldn't on macos 12
* these runners are larger so can build stuff faster too