### PR TITLE
add v4l2 crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -45,7 +45,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan ${{ matrix.args }}
+        args: --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan --exclude v4l2 ${{ matrix.args }}
   test_xcoder_logan:
     name: Test xcoder-logan
     runs-on:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan
+        args: --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan --exclude v4l2
   test_xcoder_logan:
     name: Test xcoder-logan
     runs-on:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -6,6 +6,7 @@ jobs:
   build:
     runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12-large]
     steps:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -9,6 +9,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-12-large]
+        include:
+          - os: macos-12-large
+            args: --exclude v4l2
     steps:
     - uses: actions/checkout@v1
     - name: Set Up Linux
@@ -35,14 +38,14 @@ jobs:
       uses: actions-rs/cargo@v1
       with:
         command: build
-        args: --verbose --workspace --exclude xilinx --features srt/async
+        args: --verbose --workspace --exclude xilinx --features srt/async ${{ matrix.args }}
     - name: Lint
-      run: cargo clippy --workspace --exclude xilinx --features srt/async --all-targets -- --deny warnings
+      run: cargo clippy --workspace --exclude xilinx --features srt/async --all-targets ${{ matrix.args }} -- --deny warnings
     - name: Test
       uses: actions-rs/cargo@v1
       with:
         command: test
-        args: --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan --exclude v4l2
+        args: --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan ${{ matrix.args }}
   test_xcoder_logan:
     name: Test xcoder-logan
     runs-on:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -24,6 +24,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7079075b41f533b8c61d2a4d073c4676e1f8b249ff94a393b0595db304e0dd87"
 
 [[package]]
+name = "anyhow"
+version = "1.0.81"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -31,7 +37,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -448,6 +454,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071a31f4ee85403370b58aca746f01041ede6f0da2730960ad001edc2b71b394"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "enumn"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -869,9 +886,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -1001,6 +1018,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.27.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb04e9c688eff1c89d72b407f168cf79bb9e867a9d3323ed6c01519eb9cc053"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1018,7 +1046,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1075,7 +1103,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1162,9 +1190,9 @@ checksum = "bbc83ee4a840062f368f9096d80077a9841ec117e17e7f700df81958f1451254"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.56"
+version = "1.0.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b63bdb0cd06f1f4dedf69b254734f9b45af66e4a031e42a7480257d9898b435"
+checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
 dependencies = [
  "unicode-ident",
 ]
@@ -1198,9 +1226,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.26"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4424af4bf778aae2051a77b60283332f386554255d722233d09fbfc7e30da2fc"
+checksum = "291ec9ab5efd934aaf503a6466c5d5251535d108ee747472c3977cc5acc868ef"
 dependencies = [
  "proc-macro2",
 ]
@@ -1448,7 +1476,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1519,7 +1547,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1573,9 +1601,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.15"
+version = "2.0.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a34fcf3e8b60f57e6a14301a2e916d323af98b0ea63c599441eec8558660c822"
+checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1651,7 +1679,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1731,7 +1759,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1783,7 +1811,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.15",
+ "syn 2.0.58",
 ]
 
 [[package]]
@@ -1858,6 +1886,29 @@ dependencies = [
  "form_urlencoded",
  "idna 0.3.0",
  "percent-encoding",
+]
+
+[[package]]
+name = "v4l2"
+version = "0.1.0"
+dependencies = [
+ "av-traits",
+ "nix",
+ "snafu",
+ "v4l2r",
+]
+
+[[package]]
+name = "v4l2r"
+version = "0.0.1"
+source = "git+https://github.com/Gnurou/v4l2r?rev=6091b1f0643f20435b97413635d935052f19c739#6091b1f0643f20435b97413635d935052f19c739"
+dependencies = [
+ "anyhow",
+ "bitflags 2.4.1",
+ "enumn",
+ "log",
+ "nix",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,6 +30,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0952808a6c2afd1aa8947271f3a60f1a6763c7b912d210184c5149b5cf147247"
 
 [[package]]
+name = "arrayvec"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
+
+[[package]]
 name = "async-trait"
 version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1892,6 +1898,7 @@ dependencies = [
 name = "v4l2"
 version = "0.1.0"
 dependencies = [
+ "arrayvec",
  "av-traits",
  "nix",
  "snafu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ members = [
     "qtff",
     "rfc6381",
     "kvazaar-sys",
+    "v4l2",
     "xcoder",
     "xcoder/xcoder-logan",
     "xcoder/xcoder-logan/xcoder-logan-259-sys",

--- a/v4l2/Cargo.toml
+++ b/v4l2/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "v4l2"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+av-traits = { path = "../av-traits" }
+nix = { version = "0.27", features = ["fs"] }
+snafu = "0.8.0"
+v4l2r = { git = "https://github.com/Gnurou/v4l2r", rev = "6091b1f0643f20435b97413635d935052f19c739" }

--- a/v4l2/Cargo.toml
+++ b/v4l2/Cargo.toml
@@ -7,4 +7,5 @@ edition = "2021"
 av-traits = { path = "../av-traits" }
 nix = { version = "0.27", features = ["fs"] }
 snafu = "0.8.0"
+arrayvec = "0.7.4"
 v4l2r = { git = "https://github.com/Gnurou/v4l2r", rev = "6091b1f0643f20435b97413635d935052f19c739" }

--- a/v4l2/src/encoder.rs
+++ b/v4l2/src/encoder.rs
@@ -1,0 +1,394 @@
+use av_traits::{EncodedFrameType, EncodedVideoFrame, RawVideoFrame, VideoEncoder, VideoEncoderOutput};
+use nix::{
+    fcntl::{open, OFlag},
+    sys::stat::Mode,
+};
+use snafu::Snafu;
+use std::{collections::VecDeque, fs::File, os::unix::io::FromRawFd, path::Path};
+use v4l2r::{
+    bindings, ioctl,
+    memory::{MemoryType, MmapHandle},
+    Format, PixelFormat, QueueType,
+};
+
+#[derive(Debug, Snafu)]
+pub enum V4L2EncoderError {
+    #[snafu(context(false), display("io error: {source}"))]
+    IoError { source: std::io::Error },
+    #[snafu(context(false), display("error setting format: {source}"))]
+    SetFormatError { source: ioctl::SFmtError },
+    #[snafu(context(false), display("error getting format: {source}"))]
+    GetFormatError { source: ioctl::GFmtError },
+    #[snafu(context(false), display("error starting stream: {source}"))]
+    StreamOnError { source: ioctl::StreamOnError },
+    #[snafu(context(false), display("error requesting buffers: {source}"))]
+    RequestBuffersError { source: ioctl::ReqbufsError },
+    #[snafu(context(false), display("error querying buffer: {source}"))]
+    QueryBufferError { source: ioctl::QueryBufError<ioctl::QueryBuffer> },
+    #[snafu(context(false), display("error mapping memory: {source}"))]
+    MmapError { source: ioctl::MmapError },
+    #[snafu(context(false), display("error dequeuing buffer: {source}"))]
+    DequeueBufferError { source: ioctl::DqBufError<ioctl::V4l2Buffer> },
+    #[snafu(context(false), display("error queuing buffer: {source}"))]
+    QueueBufferError { source: ioctl::QBufError<()> },
+    #[snafu(context(false), display("error getting or setting parameters: {source}"))]
+    ParametersError { source: ioctl::GParmError },
+    #[snafu(context(false), display("error getting or setting controls: {source}"))]
+    ControlError { source: ioctl::GCtrlError },
+    #[snafu(display("no available device"))]
+    NoAvailableDevice,
+    #[snafu(display("got unexpected plane layout"))]
+    UnexpectedPlaneLayout,
+}
+
+type Result<T> = core::result::Result<T, V4L2EncoderError>;
+
+pub struct V4L2Encoder<F> {
+    config: V4L2EncoderConfig,
+    fd: File,
+    capture_mappings: Vec<ioctl::PlaneMapping>,
+    output_mappings: Vec<ioctl::PlaneMapping>,
+    output_format: Format,
+    pending_frames: VecDeque<F>,
+    available_output_buffers: Vec<usize>,
+    available_capture_buffers: Vec<usize>,
+}
+
+impl<F> Drop for V4L2Encoder<F> {
+    fn drop(&mut self) {
+        let _ = ioctl::streamoff(&self.fd, QueueType::VideoOutputMplane);
+        let _ = ioctl::streamoff(&self.fd, QueueType::VideoCaptureMplane);
+        self.capture_mappings.clear();
+        self.output_mappings.clear();
+        let _ = ioctl::reqbufs::<()>(&self.fd, QueueType::VideoOutputMplane, MemoryType::Mmap, 0);
+        let _ = ioctl::reqbufs::<()>(&self.fd, QueueType::VideoCaptureMplane, MemoryType::Mmap, 0);
+    }
+}
+
+#[derive(Clone, Copy, Debug)]
+pub enum V4L2EncoderInputFormat {
+    Yuv420Planar,
+    Bgra,
+}
+
+impl V4L2EncoderInputFormat {
+    fn planes(&self) -> usize {
+        match self {
+            Self::Yuv420Planar => 3,
+            Self::Bgra => 1,
+        }
+    }
+
+    fn pixel_format(&self) -> PixelFormat {
+        PixelFormat::from_u32(match self {
+            Self::Yuv420Planar => 0x32315559,
+            Self::Bgra => 0x34524742,
+        })
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct V4L2EncoderConfig {
+    pub height: u16,
+    pub width: u16,
+    pub fps: f64,
+    pub bitrate: Option<u32>,
+    pub keyframe_interval: Option<u32>,
+    pub input_format: V4L2EncoderInputFormat,
+}
+
+const H264_PIXELFORMAT: PixelFormat = PixelFormat::from_u32(0x34363248);
+
+// XXX: There's a really counterintuitive convention used by the V4L2 API: The output of the
+// encoder is the "capture" queue, while the input to the encoder is the "output" queue.
+impl<F> V4L2Encoder<F> {
+    fn try_open_device<P: AsRef<Path>>(path: P, input_format: V4L2EncoderInputFormat) -> Option<File> {
+        let fd = unsafe { File::from_raw_fd(open(path.as_ref().as_os_str(), OFlag::O_RDWR | OFlag::O_CLOEXEC, Mode::empty()).ok()?) };
+
+        let caps: ioctl::Capability = ioctl::querycap(&fd).ok()?;
+        if !caps.capabilities.contains(ioctl::Capabilities::VIDEO_M2M_MPLANE) {
+            return None;
+        }
+
+        ioctl::reqbufs::<()>(&fd, QueueType::VideoOutputMplane, MemoryType::Mmap, 0).ok()?;
+        ioctl::reqbufs::<()>(&fd, QueueType::VideoCaptureMplane, MemoryType::Mmap, 0).ok()?;
+
+        let mut capture_formats = ioctl::FormatIterator::new(&fd, QueueType::VideoCaptureMplane);
+        if !capture_formats.any(|fmt| fmt.pixelformat == H264_PIXELFORMAT) {
+            return None;
+        }
+
+        let mut output_formats = ioctl::FormatIterator::new(&fd, QueueType::VideoOutputMplane);
+        let input_pixel_format = input_format.pixel_format();
+        if !output_formats.any(|fmt| fmt.pixelformat == input_pixel_format) {
+            return None;
+        }
+
+        Some(fd)
+    }
+
+    pub fn new(config: V4L2EncoderConfig) -> Result<Self> {
+        let paths = std::fs::read_dir("/dev")?;
+
+        let mut fd = match paths
+            .into_iter()
+            .find_map(|path| path.map(|path| Self::try_open_device(path.path(), config.input_format)).transpose())
+        {
+            Some(r) => r?,
+            None => return Err(V4L2EncoderError::NoAvailableDevice),
+        };
+
+        let output_format = Format {
+            width: config.width as _,
+            height: config.height as _,
+            pixelformat: config.input_format.pixel_format(),
+            ..Default::default()
+        };
+        let output_format: Format = ioctl::s_fmt(&mut fd, (QueueType::VideoOutputMplane, &output_format))?;
+
+        let mut capture_format: Format = ioctl::g_fmt(&fd, QueueType::VideoCaptureMplane)?;
+        capture_format.pixelformat = H264_PIXELFORMAT;
+        capture_format.width = config.width as _;
+        capture_format.height = config.height as _;
+        let _: Format = ioctl::s_fmt(&mut fd, (QueueType::VideoCaptureMplane, &capture_format))?;
+
+        // set the fps if possible
+        {
+            let mut parm: bindings::v4l2_streamparm = ioctl::g_parm(&fd, QueueType::VideoOutputMplane)?;
+            let output_parm = unsafe { &mut parm.parm.output };
+            if (output_parm.capability & bindings::V4L2_CAP_TIMEPERFRAME) != 0 {
+                let fps_denominator = if config.fps.fract() == 0.0 {
+                    1000
+                } else {
+                    // a denominator of 1001 for 29.97 or 59.94 is more
+                    // conventional
+                    1001
+                };
+                let fps_numerator = (config.fps * fps_denominator as f64).round() as _;
+                output_parm.timeperframe.numerator = fps_denominator;
+                output_parm.timeperframe.denominator = fps_numerator;
+                let _: bindings::v4l2_streamparm = ioctl::s_parm(&mut fd, parm)?;
+            }
+        }
+
+        if let Some(bitrate) = config.bitrate {
+            ioctl::s_ctrl(&mut fd, bindings::V4L2_CID_MPEG_VIDEO_BITRATE, bitrate as _)?;
+        }
+
+        if let Some(interval) = config.keyframe_interval {
+            ioctl::s_ctrl(&mut fd, bindings::V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, interval as _)?;
+        }
+
+        // We'll make sure the encoder always has 2 frames to work on before we block for output.
+        // Experimentally, this performs 50% faster than using 1 set of buffers and using 3 has no
+        // benefit over 2. Note that this currently means the encoder has a latency of 2 frames.
+        const N_BUFFERS: usize = 2;
+
+        ioctl::reqbufs(&fd, QueueType::VideoOutputMplane, MemoryType::Mmap, N_BUFFERS as _)?;
+        let output_mappings = (0..N_BUFFERS)
+            .map(|i| -> Result<_> {
+                let buf: ioctl::QueryBuffer = ioctl::querybuf(&fd, QueueType::VideoOutputMplane, i)?;
+                Ok(ioctl::mmap(&fd, buf.planes[0].mem_offset, buf.planes[0].length)?)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        ioctl::reqbufs(&fd, QueueType::VideoCaptureMplane, MemoryType::Mmap, N_BUFFERS as _)?;
+        let capture_mappings = (0..N_BUFFERS)
+            .map(|i| -> Result<_> {
+                let buf: ioctl::QueryBuffer = ioctl::querybuf(&fd, QueueType::VideoCaptureMplane, i)?;
+                Ok(ioctl::mmap(&fd, buf.planes[0].mem_offset, buf.planes[0].length)?)
+            })
+            .collect::<Result<Vec<_>>>()?;
+
+        ioctl::streamon(&fd, QueueType::VideoOutputMplane)?;
+        ioctl::streamon(&fd, QueueType::VideoCaptureMplane)?;
+
+        Ok(Self {
+            config,
+            fd,
+            output_mappings,
+            output_format,
+            capture_mappings,
+            pending_frames: VecDeque::new(),
+            available_output_buffers: (0..N_BUFFERS).collect(),
+            available_capture_buffers: (0..N_BUFFERS).collect(),
+        })
+    }
+
+    // Blocks until output is available if `flushing` is `true` or if all our buffers are full.
+    fn wait_for_output(&mut self, flushing: bool) -> Result<Option<VideoEncoderOutput<F>>> {
+        if !flushing && !self.available_capture_buffers.is_empty() {
+            // we want to saturate our buffers before blocking on frame output
+            // TODO: we could potentially make a non-blocking call here to see if any output
+            // happens to be ready
+            return Ok(None);
+        }
+
+        Ok(match self.pending_frames.pop_front() {
+            Some(f) => {
+                // dequeue an output buffer
+                let out_dqbuf: ioctl::V4l2Buffer = ioctl::dqbuf(&self.fd, QueueType::VideoOutputMplane)?;
+                self.available_output_buffers.push(out_dqbuf.index() as _);
+
+                // dequeue a capture buffer
+                let cap_dqbuf: ioctl::V4l2Buffer = ioctl::dqbuf(&self.fd, QueueType::VideoCaptureMplane)?;
+                let flags = cap_dqbuf.flags();
+                let bytes = cap_dqbuf.get_first_plane().bytesused() as usize;
+                let idx = cap_dqbuf.index() as usize;
+                self.available_capture_buffers.push(idx);
+                let data = self.capture_mappings[idx].data[..bytes].to_vec();
+                Some(VideoEncoderOutput {
+                    raw_frame: f,
+                    encoded_frame: Some(EncodedVideoFrame {
+                        data,
+                        is_keyframe: flags.contains(ioctl::BufferFlags::KEYFRAME),
+                    }),
+                })
+            }
+            None => None,
+        })
+    }
+}
+
+impl<F: RawVideoFrame<u8>> VideoEncoder for V4L2Encoder<F> {
+    type Error = V4L2EncoderError;
+    type RawVideoFrame = F;
+
+    fn encode(&mut self, input: F, frame_type: EncodedFrameType) -> Result<Option<VideoEncoderOutput<F>>> {
+        // if we have full buffers, wait for a frame to finish
+        let output = self.wait_for_output(false)?;
+
+        // queue up the capture buffer
+        {
+            let capture_buffer_index = self
+                .available_capture_buffers
+                .pop()
+                .expect("wait_for_output will block until we have an available buffer");
+
+            let cap_qbuf = ioctl::QBuffer::<MmapHandle> {
+                planes: vec![ioctl::QBufPlane::new(0)],
+                ..Default::default()
+            };
+            ioctl::qbuf::<_, ()>(&self.fd, QueueType::VideoCaptureMplane, capture_buffer_index, cap_qbuf)?;
+        }
+
+        // queue up the raw frame in an output buffer
+        {
+            let output_buffer_index = self
+                .available_output_buffers
+                .pop()
+                .expect("wait_for_output will block until we have an available buffer");
+
+            if frame_type == EncodedFrameType::Key {
+                ioctl::s_ctrl(&mut self.fd, bindings::V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME, 1)?;
+            }
+
+            let mapping = &mut self.output_mappings[output_buffer_index];
+            let mut offset = 0;
+            for i in 0..self.config.input_format.planes() {
+                let samples = input.samples(i);
+                if samples.len() > mapping.len() - offset {
+                    return Err(V4L2EncoderError::UnexpectedPlaneLayout);
+                }
+                mapping[offset..offset + samples.len()].copy_from_slice(samples);
+                offset += samples.len();
+            }
+            if offset != self.output_format.plane_fmt[0].sizeimage as usize {
+                return Err(V4L2EncoderError::UnexpectedPlaneLayout);
+            }
+
+            let out_qbuf = ioctl::QBuffer::<MmapHandle> {
+                planes: vec![ioctl::QBufPlane::new(offset)],
+                ..Default::default()
+            };
+            ioctl::qbuf::<_, ()>(&self.fd, QueueType::VideoOutputMplane, output_buffer_index, out_qbuf)?;
+
+            self.pending_frames.push_back(input);
+        }
+
+        Ok(output)
+    }
+
+    fn flush(&mut self) -> Result<Option<VideoEncoderOutput<F>>> {
+        self.wait_for_output(true)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    struct TestFrame {
+        samples: Vec<Vec<u8>>,
+    }
+
+    impl RawVideoFrame<u8> for TestFrame {
+        fn samples(&self, plane: usize) -> &[u8] {
+            &self.samples[plane]
+        }
+    }
+
+    #[test]
+    fn test_video_encoder() {
+        let mut encoder = V4L2Encoder::new(V4L2EncoderConfig {
+            width: 1920,
+            height: 1080,
+            fps: 30.0,
+            bitrate: Some(50000),
+            keyframe_interval: Some(120),
+            input_format: V4L2EncoderInputFormat::Yuv420Planar,
+        })
+        .unwrap();
+
+        let mut encoded = vec![];
+        let mut encoded_frames = 0;
+        let mut encoded_keyframes = 0;
+
+        let u = vec![200u8; 1920 * 1080 / 4];
+        let v = vec![128u8; 1920 * 1080 / 4];
+        for i in 0..90 {
+            let mut y = Vec::with_capacity(1920 * 1080);
+            for line in 0..1080 {
+                let sample = if line / 12 == i {
+                    // add some motion by drawing a line that moves from top to bottom
+                    16
+                } else {
+                    (16.0 + (line as f64 / 1080.0) * 219.0).round() as u8
+                };
+                y.resize(y.len() + 1920, sample);
+            }
+            let frame = TestFrame {
+                samples: vec![y, u.clone(), v.clone()],
+            };
+            if let Some(output) = encoder
+                .encode(frame, if i % 30 == 0 { EncodedFrameType::Key } else { EncodedFrameType::Auto })
+                .unwrap()
+            {
+                let mut encoded_frame = output.encoded_frame.expect("frame was not dropped");
+                encoded.append(&mut encoded_frame.data);
+                encoded_frames += 1;
+                if encoded_frame.is_keyframe {
+                    encoded_keyframes += 1;
+                }
+            }
+        }
+        while let Some(output) = encoder.flush().unwrap() {
+            let mut encoded_frame = output.encoded_frame.expect("frame was not dropped");
+            encoded.append(&mut encoded_frame.data);
+            encoded_frames += 1;
+            if encoded_frame.is_keyframe {
+                encoded_keyframes += 1;
+            }
+        }
+
+        assert_eq!(encoded_frames, 90);
+        assert!(encoded.len() > 5000);
+        assert!(encoded.len() < 30000);
+
+        assert_eq!(encoded_keyframes, 3);
+
+        // To inspect the output, uncomment these lines:
+        //use std::io::Write;
+        //std::fs::File::create("tmp.h264").unwrap().write_all(&encoded).unwrap();
+    }
+}

--- a/v4l2/src/encoder.rs
+++ b/v4l2/src/encoder.rs
@@ -167,16 +167,16 @@ impl<F> V4L2Encoder<F> {
                 let fps_numerator = (config.fps * fps_denominator as f64).round() as _;
                 output_parm.timeperframe.numerator = fps_denominator;
                 output_parm.timeperframe.denominator = fps_numerator;
-                let _: bindings::v4l2_streamparm = ioctl::s_parm(&mut fd, parm)?;
+                let _: bindings::v4l2_streamparm = ioctl::s_parm(&fd, parm)?;
             }
         }
 
         if let Some(bitrate) = config.bitrate {
-            ioctl::s_ctrl(&mut fd, bindings::V4L2_CID_MPEG_VIDEO_BITRATE, bitrate as _)?;
+            ioctl::s_ctrl(&fd, bindings::V4L2_CID_MPEG_VIDEO_BITRATE, bitrate as _)?;
         }
 
         if let Some(interval) = config.keyframe_interval {
-            ioctl::s_ctrl(&mut fd, bindings::V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, interval as _)?;
+            ioctl::s_ctrl(&fd, bindings::V4L2_CID_MPEG_VIDEO_H264_I_PERIOD, interval as _)?;
         }
 
         // We'll make sure the encoder always has 2 frames to work on before we block for output.
@@ -280,7 +280,7 @@ impl<F: RawVideoFrame<u8>> VideoEncoder for V4L2Encoder<F> {
                 .expect("wait_for_output will block until we have an available buffer");
 
             if frame_type == EncodedFrameType::Key {
-                ioctl::s_ctrl(&mut self.fd, bindings::V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME, 1)?;
+                ioctl::s_ctrl(&self.fd, bindings::V4L2_CID_MPEG_VIDEO_FORCE_KEY_FRAME, 1)?;
             }
 
             let mapping = &mut self.output_mappings[output_buffer_index];

--- a/v4l2/src/lib.rs
+++ b/v4l2/src/lib.rs
@@ -1,0 +1,2 @@
+mod encoder;
+pub use encoder::*;


### PR DESCRIPTION
Inspired by Scott pointing me to the Orange Pi, this is a mostly-for-fun PR that adds a `v4l2` crate. V4L2 is the Linux kernel driver / API for capturing, encoding, and decoding video. This crate adds an implementation of our video encoder trait that uses the V4L2 API.

I developed and tested it on a [Raspberry Pi Zero 2 W](https://www.raspberrypi.com/products/raspberry-pi-zero-2-w/). The test encodes 3 seconds of 1080p30 video in about 2 seconds, i.e. it runs at 150% realtime on this device. Not bad for a $15 device.