### PR TITLE
fix core2 features for no_std build

### DIFF
--- a/mpeg2/Cargo.toml
+++ b/mpeg2/Cargo.toml
@@ -10,4 +10,4 @@ std = ["core2/std"]
 [dependencies]
 byteorder = { version = "1.3.4", default-features = false }
 crc = "3.0.0"
-core2 = { version = "0.4.0", features = ["alloc"] }
+core2 = { version = "0.4.0", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
In order to build `mpeg2` with `no_std`, we need to omit default features from `core2`. Note that this was intended from the beginning – If you look at the full Cargo file, you'll see that if the `std` feature is enabled, we already enable the `core2/std` feature as well.