### PR TITLE
Unconditionally copy string data for netint logging

### DIFF
--- a/xcoder/xcoder-logan/xcoder-logan-310-sys/src/lib.rs
+++ b/xcoder/xcoder-logan/xcoder-logan-310-sys/src/lib.rs
@@ -28,7 +28,7 @@ mod logging {
     #[no_mangle]
     extern "C" fn rust_netint_logan_callback(level: c_int, message: *const c_char) {
         let r = panic::catch_unwind(|| {
-            let buf = unsafe { CStr::from_ptr(message) }.to_string_lossy();
+            let buf = unsafe { CStr::from_ptr(message) }.to_string_lossy().into_owned();
             match level as u32 {
                 crate::ni_log_level_t_NI_LOG_TRACE => log::trace!("{buf}"),
                 crate::ni_log_level_t_NI_LOG_DEBUG => log::debug!("{buf}"),
@@ -36,7 +36,7 @@ mod logging {
                 crate::ni_log_level_t_NI_LOG_FATAL | crate::ni_log_level_t_NI_LOG_ERROR => log::error!("{buf}"),
                 crate::ni_log_level_t_NI_LOG_NONE => {
                     // Do nothing
-                },
+                }
                 level => {
                     log::error!("netint log level {level} unrecognized, message was {buf}")
                 }

--- a/xcoder/xcoder-quadra/xcoder-quadra-sys/src/lib.rs
+++ b/xcoder/xcoder-quadra/xcoder-quadra-sys/src/lib.rs
@@ -28,7 +28,7 @@ mod logging {
     #[no_mangle]
     extern "C" fn rust_netint_callback(level: c_int, message: *const c_char) {
         let r = panic::catch_unwind(|| {
-            let buf = unsafe { CStr::from_ptr(message) }.to_string_lossy();
+            let buf = unsafe { CStr::from_ptr(message) }.to_string_lossy().into_owned();
             match level {
                 crate::ni_log_level_t_NI_LOG_TRACE => log::trace!("{buf}"),
                 crate::ni_log_level_t_NI_LOG_DEBUG => log::debug!("{buf}"),
@@ -36,7 +36,7 @@ mod logging {
                 crate::ni_log_level_t_NI_LOG_FATAL | crate::ni_log_level_t_NI_LOG_ERROR => log::error!("{buf}"),
                 crate::ni_log_level_t_NI_LOG_NONE => {
                     // Do nothing
-                },
+                }
                 level => {
                     log::error!("netint log level {level} unrecognized, message was {buf}")
                 }


### PR DESCRIPTION
I believe this resolves a soundness issue we're seeing with this code.

Basically we had a `Cow<'a>` where `'a` was the scope of the `rust_netint_*_callback`, and we were accidentally treating it as a `Cow<'static>`. That `Cow<'static>` was then passed through the `log` ecosystem as a format argument.