### PR TITLE
remove all usage of node16 in workflow file

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -13,7 +13,7 @@ jobs:
           - os: macos-12-large
             args: --exclude v4l2
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set Up Linux
       if: startsWith(matrix.os, 'ubuntu-')
       run: |
@@ -29,23 +29,16 @@ jobs:
         brew install kvazaar x264 ffmpeg@4
         brew link ffmpeg@4
     - name: Install Rust
-      uses: actions-rs/toolchain@v1
+      uses: actions-rust-lang/setup-rust-toolchain@v1
       with:
         toolchain: 1.77.2
         components: clippy
-        override: true
     - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose --workspace --exclude xilinx --features srt/async ${{ matrix.args }}
+      run: cargo build --verbose --workspace --exclude xilinx --features srt/async ${{ matrix.args }}
     - name: Lint
       run: cargo clippy --workspace --exclude xilinx --features srt/async --all-targets ${{ matrix.args }} -- --deny warnings
     - name: Test
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan --exclude v4l2 --exclude rkmpp ${{ matrix.args }}
+      run: cargo test --verbose --workspace --exclude xilinx --all-features --exclude xcoder-quadra --exclude xcoder-logan --exclude v4l2 --exclude rkmpp ${{ matrix.args }}
   test_xcoder_logan:
     name: Test xcoder-logan
     runs-on:
@@ -53,22 +46,18 @@ jobs:
       - netint-t408-310X2013
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.77.2
-          override: true
       - name: Initialize
         run: |
           init_rsrc_logan || true
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose -p xcoder-logan -p xcoder-logan-310-sys -- --test-threads=1
+        run: cargo test --verbose -p xcoder-logan -p xcoder-logan-310-sys -- --test-threads=1
   test_xcoder_logan_v2_compat:
     name: Test xcoder-logan v2-compat
     runs-on:
@@ -76,22 +65,18 @@ jobs:
       - netint-t408-251X1E09
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.77.2
-          override: true
       - name: Initialize
         run: |
           init_rsrc || true
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose -p xcoder-logan -p xcoder-logan-259-sys --features v2-compat -- --test-threads=1
+        run: cargo test --verbose -p xcoder-logan -p xcoder-logan-259-sys --features v2-compat -- --test-threads=1
   test_xcoder_quadra:
     name: Test xcoder-quadra
     runs-on:
@@ -99,19 +84,15 @@ jobs:
       - netint-quadra
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           lfs: true
       - name: Install Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
           toolchain: 1.77.2
-          override: true
       - name: Initialize
         run: |
           init_rsrc || true
       - name: Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose -p xcoder-quadra -p xcoder-quadra-sys -- --test-threads=1
+        run: cargo test --verbose -p xcoder-quadra -p xcoder-quadra-sys -- --test-threads=1

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,8 @@ jobs:
             args: --exclude v4l2
     steps:
     - uses: actions/checkout@v4
+      with:
+        lfs: true
     - name: Set Up Linux
       if: startsWith(matrix.os, 'ubuntu-')
       run: |


### PR DESCRIPTION
https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/

We have until May 13th to resolve this problem. Let's start now.