### PR TITLE
Enable downloading of SW frames for Quadra

### DIFF
--- a/av-traits/src/video_encoder.rs
+++ b/av-traits/src/video_encoder.rs
@@ -62,12 +62,12 @@ pub enum EncodedFrameType {
 /// {
 ///     while let Some(frame) = source.next() {
 ///         if let Some(output) = encoder.encode(frame, EncodedFrameType::Auto)? {
-///             // do something with output  
+///             // do something with output
 ///         }
 ///     }
 ///
 ///     while let Some(output) = encoder.flush()? {
-///         // do something with output  
+///         // do something with output
 ///     }
 ///
 ///     Ok(())

--- a/xcoder/xcoder-quadra/src/cropper.rs
+++ b/xcoder/xcoder-quadra/src/cropper.rs
@@ -203,7 +203,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                frame_buffer: None,
+                number_of_frame_buffers: None,
             },
             frames,
         )

--- a/xcoder/xcoder-quadra/src/cropper.rs
+++ b/xcoder/xcoder-quadra/src/cropper.rs
@@ -194,7 +194,7 @@ mod test {
     fn test_cropper() {
         let frames = read_frames("src/testdata/smptebars.h264");
 
-        let mut decoder = XcoderDecoder::new(
+        let mut decoder = XcoderDecoder::<XcoderHardwareFrame, _, _>::new(
             XcoderDecoderConfig {
                 width: 1280,
                 height: 720,
@@ -215,7 +215,7 @@ mod test {
         while let Some(frame) = decoder.read_decoded_frame().unwrap() {
             cropper
                 .crop(
-                    &frame.into(),
+                    &frame,
                     XcoderCrop {
                         x: 0,
                         y: 0,

--- a/xcoder/xcoder-quadra/src/cropper.rs
+++ b/xcoder/xcoder-quadra/src/cropper.rs
@@ -203,6 +203,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
+                buffer_count: 0,
             },
             frames,
         )

--- a/xcoder/xcoder-quadra/src/cropper.rs
+++ b/xcoder/xcoder-quadra/src/cropper.rs
@@ -203,7 +203,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                buffer_count: 0,
+                frame_buffer: None,
             },
             frames,
         )

--- a/xcoder/xcoder-quadra/src/decoder.rs
+++ b/xcoder/xcoder-quadra/src/decoder.rs
@@ -162,7 +162,7 @@ impl<F: XcoderDecodedFrame, E: Error, I: XcoderDecoderInput<E>> XcoderDecoder<F,
         let (fps_numerator, fps_denominator) = fps_to_rational(config.fps);
 
         unsafe {
-            let mut params: Box<MaybeUninit<xcoder_quadra_sys::_ni_xcoder_params>> = alloc_zeroed();
+            let mut params = alloc_zeroed();
             let code = sys::ni_decoder_init_default_params(params.as_mut_ptr(), fps_numerator, fps_denominator, 0, config.width, config.height);
             if code != sys::ni_retcode_t_NI_RETCODE_SUCCESS {
                 return Err(XcoderDecoderError::Unknown {

--- a/xcoder/xcoder-quadra/src/decoder.rs
+++ b/xcoder/xcoder-quadra/src/decoder.rs
@@ -29,7 +29,7 @@ pub struct XcoderDecoderConfig {
     /// 1) This does not allocate the space for the frame buffer itself (which could be ~50MB for an 8K 8bit frame),
     ///     that only happens on first usage of a specific buffer
     /// 2) This is an initial amount. The NETINT codebase will grow the buffer as needed
-    pub frame_buffer: Option<usize>,
+    pub number_of_frame_buffers: Option<usize>,
 }
 
 pub struct XcoderDecoderInputFrame {
@@ -209,13 +209,13 @@ impl<F: XcoderDecodedFrame, E: Error, I: XcoderDecoderInput<E>> XcoderDecoder<F,
             });
 
             if !F::HARDWARE {
-                if let Some(frame_buffer) = config.frame_buffer {
+                if let Some(number_of_frame_buffers) = config.number_of_frame_buffers {
                     // no drop guard needed here, the `(*self.session).dec_fme_buf_pool`
                     // is cleaned up by `ni_device_session_close`, which calls `ni_decoder_session_close`
 
                     let code = sys::ni_dec_fme_buffer_pool_initialize(
                         *session,
-                        frame_buffer as i32,
+                        number_of_frame_buffers as i32,
                         config.width,
                         config.height,
                         ((**session).codec_format == sys::_ni_codec_format_NI_CODEC_FORMAT_H264).into(),
@@ -430,7 +430,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                frame_buffer: None,
+                number_of_frame_buffers: None,
             },
             frames,
         )
@@ -457,7 +457,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                frame_buffer: None,
+                number_of_frame_buffers: None,
             },
             frames,
         )
@@ -510,7 +510,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                frame_buffer: Some(4),
+                number_of_frame_buffers: Some(4),
             },
             frames,
         )
@@ -540,7 +540,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                frame_buffer: None,
+                number_of_frame_buffers: None,
             },
             frames,
         )

--- a/xcoder/xcoder-quadra/src/decoder.rs
+++ b/xcoder/xcoder-quadra/src/decoder.rs
@@ -6,7 +6,7 @@ use std::{
     mem::{self, MaybeUninit},
     os::raw::c_void,
 };
-use xcoder_quadra_sys::{self as sys};
+use xcoder_quadra_sys::{self as sys, ni_pix_fmt_t_NI_PIX_FMT_YUV420P, ni_pix_fmt_t_NI_PIX_FMT_YUV420P10LE};
 
 #[derive(Clone, Copy, Debug)]
 pub enum XcoderDecoderCodec {
@@ -196,6 +196,12 @@ impl<F: XcoderDecodedFrame, E: Error, I: XcoderDecoderInput<E>> XcoderDecoder<F,
             (**session).bit_depth_factor = match config.bit_depth {
                 8 => 1,
                 10 => 2,
+                _ => return Err(XcoderDecoderError::UnsupportedBitDepth),
+            };
+
+            (**session).pixel_format = match config.bit_depth {
+                8 => ni_pix_fmt_t_NI_PIX_FMT_YUV420P as i32,
+                10 => ni_pix_fmt_t_NI_PIX_FMT_YUV420P10LE as i32,
                 _ => return Err(XcoderDecoderError::UnsupportedBitDepth),
             };
 

--- a/xcoder/xcoder-quadra/src/decoder.rs
+++ b/xcoder/xcoder-quadra/src/decoder.rs
@@ -395,6 +395,7 @@ impl<E: Error, I> XcoderDecoder<I, E> {
         &self,
         p_src_frame: &XcoderDecodedFrame,
         mut hwdl_session_data: ni_session_data_io_t,
+        return_to_buffer_pool: bool,
     ) -> Result<XcoderSoftwareFrame, XcoderDecoderError<E>> {
         let source_surface: *mut niFrameSurface1_t = p_src_frame.p_data[3] as _;
 
@@ -420,7 +421,7 @@ impl<E: Error, I> XcoderDecoder<I, E> {
             });
         }
 
-        Ok(unsafe { XcoderSoftwareFrame::new(hwdl_session_data) })
+        Ok(unsafe { XcoderSoftwareFrame::new(hwdl_session_data, return_to_buffer_pool) })
     }
 
     pub fn download_frame(&self, p_src_frame: &XcoderDecodedFrame) -> Result<XcoderSoftwareFrame, XcoderDecoderError<E>> {
@@ -456,7 +457,7 @@ impl<E: Error, I> XcoderDecoder<I, E> {
             });
         }
 
-        self.download_frame_into_buffer(p_src_frame, hwdl_session_data)
+        self.download_frame_into_buffer(p_src_frame, hwdl_session_data, !(unsafe { *self.session }).dec_fme_buf_pool.is_null())
     }
 }
 

--- a/xcoder/xcoder-quadra/src/decoder.rs
+++ b/xcoder/xcoder-quadra/src/decoder.rs
@@ -171,7 +171,9 @@ impl<F: XcoderDecodedFrame, E: Error, I: XcoderDecoderInput<E>> XcoderDecoder<F,
                 });
             }
             let mut params = mem::transmute::<Box<MaybeUninit<sys::ni_xcoder_params_t>>, Box<sys::ni_xcoder_params_t>>(params);
-            params.__bindgen_anon_1.dec_input_params.hwframes = 1;
+            if F::HARDWARE {
+                params.__bindgen_anon_1.dec_input_params.hwframes = 1;
+            }
             params.__bindgen_anon_1.dec_input_params.mcmode = config.multicore_joint_mode.into();
 
             let session = sys::ni_device_session_context_alloc_init();

--- a/xcoder/xcoder-quadra/src/lib.rs
+++ b/xcoder/xcoder-quadra/src/lib.rs
@@ -147,9 +147,9 @@ mod linux_impl {
             // safety: all zeroes are valid for ni_session_data_io_t
             let mut frame = unsafe { mem::MaybeUninit::<sys::ni_frame_t>::zeroed().assume_init() };
 
-            let use_pool = !(unsafe { *session }).dec_fme_buf_pool.is_null();
+            let return_to_buffer_pool = !(unsafe { *session }).dec_fme_buf_pool.is_null();
 
-            let code = if use_pool {
+            let code = if return_to_buffer_pool {
                 unsafe {
                     ni_decoder_frame_buffer_alloc(
                         (*session).dec_fme_buf_pool,
@@ -177,7 +177,7 @@ mod linux_impl {
                 data_io: sys::ni_session_data_io_t {
                     data: sys::_ni_session_data_io__bindgen_ty_1 { frame },
                 },
-                return_to_buffer_pool: use_pool,
+                return_to_buffer_pool,
             })
         }
 
@@ -378,7 +378,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                buffer_count: 0,
+                frame_buffer: None,
             },
             frames,
         )
@@ -456,7 +456,7 @@ mod test {
                 fps: 24.0,
                 hardware_id: None,
                 multicore_joint_mode: true,
-                buffer_count: 0,
+                frame_buffer: None,
             },
             frames,
         )

--- a/xcoder/xcoder-quadra/src/lib.rs
+++ b/xcoder/xcoder-quadra/src/lib.rs
@@ -147,7 +147,8 @@ mod linux_impl {
             // safety: all zeroes are valid for ni_session_data_io_t
             let mut frame = unsafe { mem::MaybeUninit::<sys::ni_frame_t>::zeroed().assume_init() };
 
-            let return_to_buffer_pool = !(unsafe { *session }).dec_fme_buf_pool.is_null();
+            // This is buggy, this is always set, so we're always pulling from the pool
+            let return_to_buffer_pool = !(*session).dec_fme_buf_pool.is_null();
 
             let code = if return_to_buffer_pool {
                 unsafe {
@@ -165,6 +166,8 @@ mod linux_impl {
             } else {
                 unsafe { ni_frame_buffer_alloc_dl(&mut frame, width, height, (*session).pixel_format) }
             };
+
+            frame.pixel_format = (*session).pixel_format;
 
             if code != sys::ni_retcode_t_NI_RETCODE_SUCCESS {
                 return Err(XcoderDecoderError::Unknown {

--- a/xcoder/xcoder-quadra/src/lib.rs
+++ b/xcoder/xcoder-quadra/src/lib.rs
@@ -378,7 +378,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                frame_buffer: None,
+                number_of_frame_buffers: None,
             },
             frames,
         )
@@ -456,7 +456,7 @@ mod test {
                 fps: 24.0,
                 hardware_id: None,
                 multicore_joint_mode: true,
-                frame_buffer: None,
+                number_of_frame_buffers: None,
             },
             frames,
         )

--- a/xcoder/xcoder-quadra/src/lib.rs
+++ b/xcoder/xcoder-quadra/src/lib.rs
@@ -39,10 +39,6 @@ mod linux_impl {
         pub fn as_data_io_mut_ptr(&mut self) -> *mut sys::ni_session_data_io_t {
             &mut self.data_io as _
         }
-
-        pub fn surface(&self) -> &sys::niFrameSurface1_t {
-            unsafe { &*(self.p_data[3] as *const sys::niFrameSurface1_t) }
-        }
     }
 
     unsafe impl Send for XcoderSoftwareFrame {}

--- a/xcoder/xcoder-quadra/src/scaler.rs
+++ b/xcoder/xcoder-quadra/src/scaler.rs
@@ -205,7 +205,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                buffer_count: 0,
+                frame_buffer: None,
             },
             frames,
         )

--- a/xcoder/xcoder-quadra/src/scaler.rs
+++ b/xcoder/xcoder-quadra/src/scaler.rs
@@ -196,7 +196,7 @@ mod test {
     fn test_scaler() {
         let frames = read_frames("src/testdata/smptebars.h264");
 
-        let mut decoder = XcoderDecoder::new(
+        let mut decoder = XcoderDecoder::<XcoderHardwareFrame, _, _>::new(
             XcoderDecoderConfig {
                 width: 1280,
                 height: 720,
@@ -220,7 +220,7 @@ mod test {
         .unwrap();
 
         while let Some(frame) = decoder.read_decoded_frame().unwrap() {
-            scaler.scale(&frame.into()).unwrap();
+            scaler.scale(&frame).unwrap();
         }
     }
 }

--- a/xcoder/xcoder-quadra/src/scaler.rs
+++ b/xcoder/xcoder-quadra/src/scaler.rs
@@ -205,7 +205,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
-                frame_buffer: None,
+                number_of_frame_buffers: None,
             },
             frames,
         )

--- a/xcoder/xcoder-quadra/src/scaler.rs
+++ b/xcoder/xcoder-quadra/src/scaler.rs
@@ -205,6 +205,7 @@ mod test {
                 fps: 29.97,
                 hardware_id: None,
                 multicore_joint_mode: false,
+                buffer_count: 0,
             },
             frames,
         )


### PR DESCRIPTION
* Enable downloading of SW frames for Quadra via `download_frame`, without intermediate frames.
* Allow for enabling frame buffer, useful for when using SW frames, via `number_of_frame_buffers`.
* Exposed the `xcoder_quadra_sys` to consumers.