### PR TITLE
Pin Ubuntu runner to 22.04

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-12-large]
+        os: [ubuntu-22.04, macos-12-large]
         include:
           - os: macos-12-large
             args: --exclude v4l2


### PR DESCRIPTION
We're not quite ready to switch to 24.04 just yet.