### PR TITLE
do not set `vbv_buffer_size`

### DIFF
--- a/xcoder/xcoder-quadra/src/encoder.rs
+++ b/xcoder/xcoder-quadra/src/encoder.rs
@@ -215,18 +215,6 @@ impl<F> XcoderEncoder<F> {
                             XcoderH265Profile::Main10 => 2,
                         };
                     }
-                    if let Some(bitrate) = config.bitrate {
-                        // This specifies the size of the VBV (CPB) buffer in milliseconds.
-                        // The range of supported values of `vbvBufferSize` is 0, and 10 to 3000. For example 3000 should be set for 3 seconds.
-                        // Given a particular bitrate value, the maximum value of vbvBufferSize without leading to insufficient resource error is not documented.
-                        // For each bitrate range, we maximize vbvBufferSize value that does not exceed the Quadra encoder's processing capacity by trial and error.
-                        cfg_enc_params.rc.vbv_buffer_size = match bitrate {
-                            0..=80_000_000 => 3000,
-                            80_000_001..=120_000_000 => 2000,
-                            120_000_001..=240_000_000 => 1000,
-                            _ => 0,
-                        }
-                    };
                 }
             }
 


### PR DESCRIPTION
With Quadra firmware 4.9.2, setting this parameter no longer appears to be necessary, and in fact is harmful. Setting it to 0 as this code was doing for larger bitrates appears to effectively negate the bitrate target, with a significant difference in quality. The `ffmpeg` command below produced an encoding with 18 Mbps (compare to target 200 Mbps) and a VMAF (harmonic mean) of 79.4. By removing the `:vbvBufferSize=0`, we instead reached 185 Mbps and 86.5, respectively.

```
ffmpeg -y -nostdin -hide_banner \
    -video_size 7680x4320 -r 30 -pixel_format yuv420p -i avs8kraw30.yuv420p.yuv \
    -c:v h265_ni_quadra_enc -xcoder-params 'intraPeriod=90:RcEnable=1:bitrate=200000000:vbvBufferSize=0:gopPresetIdx=9:multicoreJointMode=1' avs8kraw30.cur.mp4
```