### PR TITLE
Implement proper lifetimes for xilinx structs

### DIFF
--- a/xilinx/src/lib.rs
+++ b/xilinx/src/lib.rs
@@ -1,6 +1,10 @@
 pub mod sys;
 pub use sys::*;
 
+/*---- context ----*/
+pub mod xrm_context;
+pub use xrm_context::*;
+
 /*---- transcoder ----*/
 pub mod xlnx_transcoder_utils;
 pub use xlnx_transcoder_utils::*;

--- a/xilinx/src/xlnx_decoder.rs
+++ b/xilinx/src/xlnx_decoder.rs
@@ -145,7 +145,7 @@ impl<'a> Drop for XlnxDecoder<'a> {
 
 #[cfg(test)]
 mod decoder_tests {
-    use crate::{tests::*, xlnx_dec_props::*, xlnx_dec_utils::*, xlnx_decoder::*, xlnx_error::*};
+    use crate::{tests::*, xlnx_dec_props::*, xlnx_dec_utils::*, xlnx_decoder::*, xlnx_error::*, xrm_context::*};
     use std::{fs::File, io::Read};
 
     const H265_TEST_FILE_PATH: &str = "src/testdata/hvc1.1.6.L150.90.h265";
@@ -175,9 +175,9 @@ mod decoder_tests {
 
         let mut xma_dec_props = XlnxXmaDecoderProperties::from(dec_props);
 
-        let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
-        let dec_load = xlnx_calc_dec_load(xrm_ctx, xma_dec_props.as_mut()).unwrap();
-        let mut xlnx_dec_ctx = XlnxDecoderXrmCtx::new(xrm_ctx, None, None, dec_load);
+        let xrm_ctx = XrmContext::new();
+        let dec_load = xlnx_calc_dec_load(&xrm_ctx, xma_dec_props.as_mut()).unwrap();
+        let mut xlnx_dec_ctx = XlnxDecoderXrmCtx::new(&xrm_ctx, None, None, dec_load);
 
         xlnx_reserve_dec_resource(&mut xlnx_dec_ctx).unwrap();
 
@@ -313,9 +313,9 @@ mod decoder_tests {
 
             let mut xma_dec_props = XlnxXmaDecoderProperties::from(dec_props);
 
-            let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
-            let dec_load = xlnx_calc_dec_load(xrm_ctx, xma_dec_props.as_mut()).unwrap();
-            let mut xlnx_dec_ctx = XlnxDecoderXrmCtx::new(xrm_ctx, None, None, dec_load);
+            let xrm_ctx = XrmContext::new();
+            let dec_load = xlnx_calc_dec_load(&xrm_ctx, xma_dec_props.as_mut()).unwrap();
+            let mut xlnx_dec_ctx = XlnxDecoderXrmCtx::new(&xrm_ctx, None, None, dec_load);
 
             xlnx_reserve_dec_resource(&mut xlnx_dec_ctx).unwrap();
 

--- a/xilinx/src/xlnx_encoder.rs
+++ b/xilinx/src/xlnx_encoder.rs
@@ -95,7 +95,7 @@ impl<'a> Drop for XlnxEncoder<'a> {
 
 #[cfg(test)]
 mod encoder_tests {
-    use crate::{tests::*, xlnx_enc_props::*, xlnx_enc_utils::*, xlnx_encoder::*};
+    use crate::{tests::*, xlnx_enc_props::*, xlnx_enc_utils::*, xlnx_encoder::*, xrm_context::*};
 
     fn encode_raw(codec_id: i32, profile: i32, level: i32) -> i32 {
         let mut frame_props = XmaFrameProperties {
@@ -156,9 +156,9 @@ mod encoder_tests {
 
         let mut xma_enc_props = XlnxXmaEncoderProperties::try_from(enc_props).unwrap();
 
-        let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
-        let enc_load = xlnx_calc_enc_load(xrm_ctx, xma_enc_props.as_mut()).unwrap();
-        let mut xlnx_enc_ctx = XlnxEncoderXrmCtx::new(xrm_ctx, None, None, enc_load);
+        let xrm_ctx = XrmContext::new();
+        let enc_load = xlnx_calc_enc_load(&xrm_ctx, xma_enc_props.as_mut()).unwrap();
+        let mut xlnx_enc_ctx = XlnxEncoderXrmCtx::new(&xrm_ctx, None, None, enc_load);
 
         xlnx_reserve_enc_resource(&mut xlnx_enc_ctx).unwrap();
 

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -115,7 +115,7 @@ impl<'a> Drop for XlnxScaler<'a> {
 
 #[cfg(test)]
 mod scaler_tests {
-    use crate::{tests::*, xlnx_scal_props::*, xlnx_scal_utils::*, xlnx_scaler::*};
+    use crate::{tests::*, xlnx_scal_props::*, xlnx_scal_utils::*, xlnx_scaler::*, xrm_context::*};
 
     #[test]
     fn test_abr_scale() {
@@ -146,9 +146,9 @@ mod scaler_tests {
 
         let mut xma_scal_props = XlnxXmaScalerProperties::from(scal_props);
 
-        let xrm_ctx = unsafe { xrmCreateContext(XRM_API_VERSION_1) };
-        let scal_load = xlnx_calc_scal_load(xrm_ctx, xma_scal_props.as_mut()).unwrap();
-        let mut xlnx_scal_ctx = XlnxScalerXrmCtx::new(xrm_ctx, None, None, scal_load, 3);
+        let xrm_ctx = XrmContext::new();
+        let scal_load = xlnx_calc_scal_load(&xrm_ctx, xma_scal_props.as_mut()).unwrap();
+        let mut xlnx_scal_ctx = XlnxScalerXrmCtx::new(&xrm_ctx, None, None, scal_load, 3);
 
         xlnx_reserve_scal_resource(&mut xlnx_scal_ctx).unwrap();
 

--- a/xilinx/src/xrm_context.rs
+++ b/xilinx/src/xrm_context.rs
@@ -27,9 +27,7 @@ impl Default for XrmContext {
 impl Drop for XrmContext {
     fn drop(&mut self) {
         unsafe {
-            unsafe {
-                sys::xrmDestroyContext(self.context);
-            }
+            sys::xrmDestroyContext(self.context);
         }
     }
 }

--- a/xilinx/src/xrm_context.rs
+++ b/xilinx/src/xrm_context.rs
@@ -1,0 +1,35 @@
+use crate::sys;
+
+/// A wrapper of the XrmContext which will correctly drop the context when dropped
+pub struct XrmContext {
+    context: sys::xrmContext,
+}
+
+impl XrmContext {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// SAFETY: If the `XrmContext` wrapping structure is dropped this raw value may
+    /// be freed. Do not use unless the source `XrmContext` still exists.
+    pub unsafe fn raw(&self) -> sys::xrmContext {
+        self.context
+    }
+}
+
+impl Default for XrmContext {
+    fn default() -> Self {
+        let context = unsafe { sys::xrmCreateContext(sys::XRM_API_VERSION_1) };
+        Self { context }
+    }
+}
+
+impl Drop for XrmContext {
+    fn drop(&mut self) {
+        unsafe {
+            unsafe {
+                sys::xrmDestroyContext(self.context);
+            }
+        }
+    }
+}


### PR DESCRIPTION
Ownership and lifetimes in xilinx structs have previously been pretty murky. This PR makes relationships between data more clear, and closes several soundness holes relating to drop order. In particular this would have entirely prevented the problem seen in https://github.com/sportsball-ai/av-service/pull/377