### PR TITLE
Make API safer and simpler

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -139,7 +139,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -505,7 +505,7 @@ checksum = "6fd000fd6988e73bbe993ea3db9b1aa64906ab88766d654973924340c8cddb42"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -532,7 +532,7 @@ name = "ffmpeg"
 version = "0.1.0"
 dependencies = [
  "ffmpeg-sys-next",
- "thiserror",
+ "thiserror 1.0.40",
  "trybuild",
 ]
 
@@ -1099,7 +1099,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1156,7 +1156,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1248,14 +1248,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d3928fb5db768cb86f891ff014f0144589297e3c6a1aba6ed7cecfdace270c7"
 dependencies = [
  "proc-macro2",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.79"
+version = "1.0.92"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835ff2298f5721608eb1a980ecaee1aef2c132bf95ecc026a11b7bf3c01c02e"
+checksum = "37d3544b3f2748c54e147655edb5025752e2303145b5aefb3c3ea2c78b973bb0"
 dependencies = [
  "unicode-ident",
 ]
@@ -1556,7 +1556,7 @@ checksum = "291a097c63d8497e00160b166a967a4a79c64f3facdd01cbd7502231688d77df"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1587,12 +1587,6 @@ name = "shlex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43b2853a4d09f215c24cc5489c992ce46052d359b5109343cbafbf26bc62f8a3"
-
-[[package]]
-name = "simple-error"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc47a29ce97772ca5c927f75bac34866b16d64e07f330c3248e2d7226623901b"
 
 [[package]]
 name = "slab"
@@ -1627,7 +1621,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1681,9 +1675,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.58"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44cfb93f38070beee36b3fef7d4f5a16f27751d94b187b666a5cc5e9b0d30687"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1748,7 +1742,16 @@ version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "978c9a314bd8dc99be594bc3c175faaa9794be04a5a5e153caba6915336cebac"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.40",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+dependencies = [
+ "thiserror-impl 2.0.11",
 ]
 
 [[package]]
@@ -1759,7 +1762,18 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1839,7 +1853,7 @@ checksum = "630bdcf245f78637c13ec01ffae6187cca34625e8c63150d424b59e55af2675e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1891,7 +1905,7 @@ checksum = "5f4f31f56159e98206da9efd823404b79b6ef3143b4a7ab76e67b1751b25a4ab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.58",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1989,7 +2003,7 @@ dependencies = [
  "enumn",
  "log",
  "nix",
- "thiserror",
+ "thiserror 1.0.40",
 ]
 
 [[package]]
@@ -2466,5 +2480,5 @@ dependencies = [
  "h265",
  "libloading 0.8.3",
  "scopeguard",
- "simple-error",
+ "thiserror 2.0.11",
 ]

--- a/xilinx/Cargo.toml
+++ b/xilinx/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 libloading = "0.8.3"
-simple-error = "0.2.1"
+thiserror = "2.0.11"
 
 [build-dependencies]
 # We're very permissive here with bindgen due to https://github.com/rust-lang/cargo/issues/5237

--- a/xilinx/src/xlnx_dec_utils.rs
+++ b/xilinx/src/xlnx_dec_utils.rs
@@ -1,9 +1,8 @@
 use std::{ffi::CString, os::raw::c_char, str::from_utf8};
 
 use libloading::{Library, Symbol};
-use simple_error::{bail, SimpleError};
 
-use crate::{strcpy_to_arr_i8, sys::*, xrm_precision_1000000_bitmask, XrmContext};
+use crate::{strcpy_to_arr_i8, sys::*, xrm_precision_1000000_bitmask, Error, XlnxError, XrmContext, XrmPlugin};
 
 const DEC_PLUGIN_NAME: &[u8] = b"xrmU30DecPlugin\0";
 
@@ -38,30 +37,21 @@ impl<'a> XlnxDecoderXrmCtx<'a> {
 
 /// Calculates the decoder load uing the xrmU30Dec plugin.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn xlnx_calc_dec_load(xrm_ctx: &XrmContext, xma_dec_props: *mut XmaDecoderProperties) -> Result<i32, SimpleError> {
+pub(crate) fn xlnx_calc_dec_load(xrm_ctx: &XrmContext, xma_dec_props: *mut XmaDecoderProperties) -> Result<i32, Error> {
     let func_id = 0;
     let mut plugin_param: xrmPluginFuncParam = Default::default();
     unsafe {
-        match Library::new("/opt/xilinx/xrm/plugin/libxmaPropsTOjson.so") {
-            Ok(lib) => {
-                match lib
-                    .get::<Symbol<extern "C" fn(props: *mut XmaDecoderProperties, function: *const c_char, json_params: *mut c_char)>>(b"convertXmaPropsToJson")
-                {
-                    Ok(convert_xma_props_to_json) => {
-                        let function = CString::new("DECODER").unwrap();
-                        convert_xma_props_to_json(xma_dec_props, function.as_ptr(), plugin_param.input.as_mut_ptr());
-                    }
-                    Err(e) => bail!("{}", e),
-                }
-            }
-            Err(e) => bail!("{}", e),
-        };
+        let lib = Library::new("/opt/xilinx/xrm/plugin/libxmaPropsTOjson.so")?;
+        let convert_xma_props_to_json =
+            lib.get::<Symbol<extern "C" fn(props: *mut XmaDecoderProperties, function: *const c_char, json_params: *mut c_char)>>(b"convertXmaPropsToJson")?;
+        let function = CString::new("DECODER").unwrap();
+        convert_xma_props_to_json(xma_dec_props, function.as_ptr(), plugin_param.input.as_mut_ptr());
     }
 
     unsafe {
         let ret = xrmExecPluginFunc(xrm_ctx.raw(), DEC_PLUGIN_NAME.as_ptr() as *mut i8, func_id, &mut plugin_param);
         if ret != XRM_SUCCESS as i32 {
-            bail!("XRM decoder plugin failed to calculate decoder load. error: {}", ret);
+            return Err(XlnxError::new(ret, Some("XRM decoder plugin failed to calculate decoder load.".to_string())).into());
         }
     }
     // parse the load from the output buffer of plugin param.
@@ -74,13 +64,13 @@ pub fn xlnx_calc_dec_load(xrm_ctx: &XrmContext, xma_dec_props: *mut XmaDecoderPr
     let load = dec_plugin_output.parse::<i32>().unwrap_or(-1);
 
     if load == -1 {
-        bail!("unable to parse load calculation from XRM decoder plugin");
+        return Err(Error::MalformedPluginResponse { plugin: XrmPlugin::Decoder });
     }
 
     Ok(load)
 }
 
-fn xlnx_fill_dec_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, dec_load: i32, device_id: Option<u32>) -> Result<(), SimpleError> {
+fn xlnx_fill_dec_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, dec_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     cu_pool_prop.cuListNum = 1;
 
     let mut device_info = 0;
@@ -107,20 +97,31 @@ fn xlnx_fill_dec_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, dec_load: i3
     Ok(())
 }
 
-pub fn xlnx_reserve_dec_resource(xlnx_dec_ctx: &mut XlnxDecoderXrmCtx<'_>) -> Result<Box<xrmCuPoolResInforV2>, SimpleError> {
+pub(crate) fn xlnx_reserve_dec_resource(xlnx_dec_ctx: &mut XlnxDecoderXrmCtx<'_>) -> Result<Box<xrmCuPoolResInforV2>, Error> {
     let mut cu_pool_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
     let mut cu_pool_res_infor: Box<xrmCuPoolResInforV2> = Box::new(Default::default());
     xlnx_fill_dec_pool_props(&mut cu_pool_prop, xlnx_dec_ctx.dec_load, xlnx_dec_ctx.device_id)?;
 
     unsafe {
+        // If this context was used for an allocation previously, release it now.
+        // It's expected that this is dead code, but if it does somehow get run
+        // it would prevent a leak of the CU pool.
+        if let Some(xrm_reserve_id) = xlnx_dec_ctx.xrm_reserve_id {
+            if xrmCuPoolRelinquishV2(xlnx_dec_ctx.xrm_ctx.raw(), xrm_reserve_id) {
+                xlnx_dec_ctx.xrm_reserve_id = None;
+            } else {
+                return Err(Error::FailedToReleaseCuPool { plugin: XrmPlugin::Decoder });
+            }
+        }
+
         let num_cu_pool = xrmCheckCuPoolAvailableNumV2(xlnx_dec_ctx.xrm_ctx.raw(), cu_pool_prop.as_mut());
         if num_cu_pool <= 0 {
-            bail!("no decoder resources available for allocation")
+            return Err(Error::ReserveCuPoolError { plugin: XrmPlugin::Decoder });
         }
 
         let xrm_reserve_id = xrmCuPoolReserveV2(xlnx_dec_ctx.xrm_ctx.raw(), cu_pool_prop.as_mut(), cu_pool_res_infor.as_mut());
         if xrm_reserve_id == 0 {
-            bail!("failed to reserve decode cu pool")
+            return Err(Error::ReserveCuPoolError { plugin: XrmPlugin::Decoder });
         }
         xlnx_dec_ctx.xrm_reserve_id = Some(xrm_reserve_id);
     }
@@ -129,7 +130,7 @@ pub fn xlnx_reserve_dec_resource(xlnx_dec_ctx: &mut XlnxDecoderXrmCtx<'_>) -> Re
 }
 
 /// Allocates decoder CU
-fn xlnx_dec_cu_alloc(xma_dec_props: &mut XmaDecoderProperties, xlnx_dec_ctx: &mut XlnxDecoderXrmCtx<'_>) -> Result<(), SimpleError> {
+fn xlnx_dec_cu_alloc(xma_dec_props: &mut XmaDecoderProperties, xlnx_dec_ctx: &mut XlnxDecoderXrmCtx<'_>) -> Result<(), Error> {
     // Allocate xrm decoder
     let mut decode_cu_list_prop = Box::new(xrmCuListPropertyV2 {
         cuNum: 2,
@@ -165,16 +166,30 @@ fn xlnx_dec_cu_alloc(xma_dec_props: &mut XmaDecoderProperties, xlnx_dec_ctx: &mu
             decode_cu_list_prop.cuProps[1].poolId = reserve_id;
         }
         (None, None) => {
-            bail!("failed to allocate decode cu list: no device id or reserve id provided");
+            return Err(Error::ReserveCuPoolError { plugin: XrmPlugin::Scaler });
         }
     }
 
-    if unsafe { xrmCuListAllocV2(xlnx_dec_ctx.xrm_ctx.raw(), decode_cu_list_prop.as_mut(), xlnx_dec_ctx.cu_list_res.as_mut()) } != XRM_SUCCESS as _ {
-        bail!(
-            "failed to allocate decode cu list from reserve id {:?} and device id {:?}",
-            xlnx_dec_ctx.xrm_reserve_id,
-            xlnx_dec_ctx.device_id
-        );
+    // If this context was used for a reservation previously, release it now.
+    // This is almost certainly dead code but if it does somehow get run
+    // it would prevent a leak of CU resources.
+    if xlnx_dec_ctx.decode_res_in_use {
+        if unsafe { xrmCuListReleaseV2(xlnx_dec_ctx.xrm_ctx.raw(), xlnx_dec_ctx.cu_list_res.as_mut()) } {
+            xlnx_dec_ctx.decode_res_in_use = false;
+        } else {
+            return Err(Error::FailedToReleaseCu { plugin: XrmPlugin::Decoder });
+        }
+    }
+
+    // Now make the new reservation
+    let ret = unsafe { xrmCuListAllocV2(xlnx_dec_ctx.xrm_ctx.raw(), decode_cu_list_prop.as_mut(), xlnx_dec_ctx.cu_list_res.as_mut()) };
+    if ret != XRM_SUCCESS as _ {
+        return Err(Error::ReserveCuError {
+            plugin: XrmPlugin::Decoder,
+            reserve_id: xlnx_dec_ctx.xrm_reserve_id,
+            device_id: xlnx_dec_ctx.device_id,
+            xlnx_error_code: ret,
+        });
     }
 
     xlnx_dec_ctx.decode_res_in_use = true;
@@ -195,12 +210,12 @@ fn xlnx_dec_cu_alloc(xma_dec_props: &mut XmaDecoderProperties, xlnx_dec_ctx: &mu
 pub(crate) fn xlnx_create_dec_session(
     xma_dec_props: &mut XmaDecoderProperties,
     xlnx_dec_ctx: &mut XlnxDecoderXrmCtx<'_>,
-) -> Result<*mut XmaDecoderSession, SimpleError> {
+) -> Result<*mut XmaDecoderSession, Error> {
     xlnx_dec_cu_alloc(xma_dec_props, xlnx_dec_ctx)?;
 
     let dec_session = unsafe { xma_dec_session_create(xma_dec_props) };
     if dec_session.is_null() {
-        bail!("failed to create decoder session. Session is null")
+        return Err(Error::SessionCreateFailed { plugin: XrmPlugin::Decoder });
     }
 
     Ok(dec_session)
@@ -212,11 +227,11 @@ impl<'a> Drop for XlnxDecoderXrmCtx<'a> {
             if self.xrm_ctx.raw().is_null() {
                 return;
             }
-            if let Some(xrm_reserve_id) = self.xrm_reserve_id {
-                let _ = xrmCuPoolRelinquishV2(self.xrm_ctx.raw(), xrm_reserve_id);
-            }
             if self.decode_res_in_use {
                 let _ = xrmCuListReleaseV2(self.xrm_ctx.raw(), self.cu_list_res.as_mut());
+            }
+            if let Some(xrm_reserve_id) = self.xrm_reserve_id {
+                let _ = xrmCuPoolRelinquishV2(self.xrm_ctx.raw(), xrm_reserve_id);
             }
         }
     }

--- a/xilinx/src/xlnx_dec_utils.rs
+++ b/xilinx/src/xlnx_dec_utils.rs
@@ -13,7 +13,7 @@ pub struct XlnxDecBuffer<'a> {
     pub allocated: usize,
 }
 
-pub struct XlnxDecoderXrmCtx<'a> {
+pub(crate) struct XlnxDecoderXrmCtx<'a> {
     pub xrm_reserve_id: Option<u64>,
     pub device_id: Option<u32>,
     pub dec_load: i32,
@@ -37,7 +37,7 @@ impl<'a> XlnxDecoderXrmCtx<'a> {
 
 /// Calculates the decoder load uing the xrmU30Dec plugin.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub(crate) fn xlnx_calc_dec_load(xrm_ctx: &XrmContext, xma_dec_props: *mut XmaDecoderProperties) -> Result<i32, Error> {
+pub fn xlnx_calc_dec_load(xrm_ctx: &XrmContext, xma_dec_props: *mut XmaDecoderProperties) -> Result<i32, Error> {
     let func_id = 0;
     let mut plugin_param: xrmPluginFuncParam = Default::default();
     unsafe {

--- a/xilinx/src/xlnx_decoder.rs
+++ b/xilinx/src/xlnx_decoder.rs
@@ -80,7 +80,7 @@ impl<'a> XlnxDecoder<'a> {
             unsafe {
                 self.in_buf.data.buffer = buf.as_mut_ptr() as *mut _ as *mut std::ffi::c_void;
                 self.in_buf.alloc_size = buf.len() as i32;
-                self.in_buf.pts = pts;
+                self.in_buf.pts = pts as i32;
                 self.in_buf.is_eof = 0;
 
                 ret = xma_dec_session_send_data(self.dec_session, &mut self.in_buf, &mut data_used);

--- a/xilinx/src/xlnx_enc_utils.rs
+++ b/xilinx/src/xlnx_enc_utils.rs
@@ -1,11 +1,10 @@
-use crate::{strcpy_to_arr_i8, sys::*, xrm_precision_1000000_bitmask, XrmContext};
+use crate::{strcpy_to_arr_i8, sys::*, xrm_precision_1000000_bitmask, Error, XlnxError, XrmContext, XrmPlugin};
 use libloading::{Library, Symbol};
-use simple_error::{bail, SimpleError};
 use std::{ffi::CString, os::raw::c_char, str::from_utf8};
 
 const ENC_PLUGIN_NAME: &[u8] = b"xrmU30EncPlugin\0";
 
-pub struct XlnxEncoderXrmCtx<'a> {
+pub(crate) struct XlnxEncoderXrmCtx<'a> {
     pub xrm_reserve_id: Option<u64>,
     pub device_id: Option<u32>,
     pub enc_load: i32,
@@ -29,30 +28,21 @@ impl<'a> XlnxEncoderXrmCtx<'a> {
 
 /// Calculates the encoder load uing the xrmU30Enc plugin.
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn xlnx_calc_enc_load(xrm_ctx: &XrmContext, xma_enc_props: *mut XmaEncoderProperties) -> Result<i32, SimpleError> {
+pub fn xlnx_calc_enc_load(xrm_ctx: &XrmContext, xma_enc_props: *mut XmaEncoderProperties) -> Result<i32, Error> {
     let func_id = 0;
     let mut plugin_param: xrmPluginFuncParam = Default::default();
     unsafe {
-        match Library::new("/opt/xilinx/xrm/plugin/libxmaPropsTOjson.so") {
-            Ok(lib) => {
-                match lib
-                    .get::<Symbol<extern "C" fn(props: *mut XmaEncoderProperties, function: *const c_char, json_params: *mut c_char)>>(b"convertXmaPropsToJson")
-                {
-                    Ok(convert_xma_props_to_json) => {
-                        let function = CString::new("ENCODER").unwrap();
-                        convert_xma_props_to_json(xma_enc_props, function.as_ptr(), plugin_param.input.as_mut_ptr());
-                    }
-                    Err(e) => bail!("{}", e),
-                }
-            }
-            Err(e) => bail!("{}", e),
-        };
+        let lib = Library::new("/opt/xilinx/xrm/plugin/libxmaPropsTOjson.so")?;
+        let convert_xma_props_to_json =
+            lib.get::<Symbol<extern "C" fn(props: *mut XmaEncoderProperties, function: *const c_char, json_params: *mut c_char)>>(b"convertXmaPropsToJson")?;
+        let function = CString::new("ENCODER").unwrap();
+        convert_xma_props_to_json(xma_enc_props, function.as_ptr(), plugin_param.input.as_mut_ptr());
     }
 
     unsafe {
         let ret = xrmExecPluginFunc(xrm_ctx.raw(), ENC_PLUGIN_NAME.as_ptr() as *mut i8, func_id, &mut plugin_param);
         if ret != XRM_SUCCESS as i32 {
-            bail!("XRM encoder plugin failed to calculate encoder load. error: {}", ret);
+            return Err(XlnxError::new(ret, Some("XRM encoder plugin failed to calculate encoder load.".to_string())).into());
         }
     }
     // parse the load from the output buffer of plugin param.
@@ -65,13 +55,13 @@ pub fn xlnx_calc_enc_load(xrm_ctx: &XrmContext, xma_enc_props: *mut XmaEncoderPr
     let load = enc_plugin_output.parse::<i32>().unwrap_or(-1);
 
     if load == -1 {
-        bail!("unable to parse load calculation from XRM encoder plugin");
+        return Err(Error::MalformedPluginResponse { plugin: XrmPlugin::Encoder });
     }
 
     Ok(load)
 }
 
-fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, enc_count: i32, enc_load: i32, device_id: Option<u32>) -> Result<(), SimpleError> {
+fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, enc_count: i32, enc_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     cu_pool_prop.cuListNum = 1;
     let mut cu_num = 0;
     let mut device_info = 0;
@@ -103,7 +93,7 @@ fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, enc_count: i
     Ok(())
 }
 
-pub fn xlnx_reserve_enc_resource(xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<Box<xrmCuPoolResInforV2>, SimpleError> {
+pub(crate) fn xlnx_reserve_enc_resource(xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<Box<xrmCuPoolResInforV2>, Error> {
     let enc_count = 1;
     let mut cu_pool_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
     let mut cu_pool_res_infor: Box<xrmCuPoolResInforV2> = Box::new(Default::default());
@@ -112,12 +102,12 @@ pub fn xlnx_reserve_enc_resource(xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result
     unsafe {
         let num_cu_pool = xrmCheckCuPoolAvailableNumV2(xlnx_enc_ctx.xrm_ctx.raw(), cu_pool_prop.as_mut());
         if num_cu_pool <= 0 {
-            bail!("no encoder resources avaliable for allocation")
+            return Err(Error::ReserveCuPoolError { plugin: XrmPlugin::Encoder });
         }
 
         let xrm_reserve_id: u64 = xrmCuPoolReserveV2(xlnx_enc_ctx.xrm_ctx.raw(), cu_pool_prop.as_mut(), cu_pool_res_infor.as_mut());
         if xrm_reserve_id == 0 {
-            bail!("failed to reserve encode cu pool")
+            return Err(Error::ReserveCuPoolError { plugin: XrmPlugin::Encoder });
         }
         xlnx_enc_ctx.xrm_reserve_id = Some(xrm_reserve_id);
     }
@@ -126,7 +116,7 @@ pub fn xlnx_reserve_enc_resource(xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result
 }
 
 /// Allocated encoder CU
-fn xlnx_enc_cu_alloc(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), SimpleError> {
+fn xlnx_enc_cu_alloc(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<(), Error> {
     // Allocate xrm encoder cu
     let mut encode_cu_list_prop = Box::new(xrmCuListPropertyV2 {
         cuNum: 2,
@@ -162,16 +152,31 @@ fn xlnx_enc_cu_alloc(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mu
             encode_cu_list_prop.cuProps[1].poolId = reserve_id;
         }
         (None, None) => {
-            bail!("failed to allocate encode cu list: no device id or reserve id provided");
+            return Err(Error::RequiredParameterMissing {
+                parameter_names: "device_id or reserve_id",
+            });
         }
     }
 
-    if unsafe { xrmCuListAllocV2(xlnx_enc_ctx.xrm_ctx.raw(), encode_cu_list_prop.as_mut(), xlnx_enc_ctx.cu_list_res.as_mut()) } != XRM_SUCCESS as _ {
-        bail!(
-            "failed to allocate encode cu list from reserve id {:?} and device id {:?}",
-            xlnx_enc_ctx.xrm_reserve_id,
-            xlnx_enc_ctx.device_id
-        );
+    // If this context was used for a reservation previously, release it now.
+    // This is almost certainly dead code but if it does somehow get run
+    // it would prevent a leak of CU resources.
+    if xlnx_enc_ctx.encode_res_in_use {
+        if unsafe { xrmCuListReleaseV2(xlnx_enc_ctx.xrm_ctx.raw(), xlnx_enc_ctx.cu_list_res.as_mut()) } {
+            xlnx_enc_ctx.encode_res_in_use = false;
+        } else {
+            return Err(Error::FailedToReleaseCu { plugin: XrmPlugin::Encoder });
+        }
+    }
+
+    let ret = unsafe { xrmCuListAllocV2(xlnx_enc_ctx.xrm_ctx.raw(), encode_cu_list_prop.as_mut(), xlnx_enc_ctx.cu_list_res.as_mut()) };
+    if ret != XRM_SUCCESS as _ {
+        return Err(Error::ReserveCuError {
+            plugin: XrmPlugin::Encoder,
+            reserve_id: xlnx_enc_ctx.xrm_reserve_id,
+            device_id: xlnx_enc_ctx.device_id,
+            xlnx_error_code: ret,
+        });
     }
     xlnx_enc_ctx.encode_res_in_use = true;
 
@@ -188,15 +193,12 @@ fn xlnx_enc_cu_alloc(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mu
 }
 
 /// Attempts to creat encoder session
-pub(crate) fn xlnx_create_enc_session(
-    xma_enc_props: &mut XmaEncoderProperties,
-    xlnx_enc_ctx: &mut XlnxEncoderXrmCtx,
-) -> Result<*mut XmaEncoderSession, SimpleError> {
+pub(crate) fn xlnx_create_enc_session(xma_enc_props: &mut XmaEncoderProperties, xlnx_enc_ctx: &mut XlnxEncoderXrmCtx) -> Result<*mut XmaEncoderSession, Error> {
     xlnx_enc_cu_alloc(xma_enc_props, xlnx_enc_ctx)?;
 
     let enc_session = unsafe { xma_enc_session_create(xma_enc_props) };
     if enc_session.is_null() {
-        bail!("failed to create encoder session. Session is null");
+        return Err(Error::SessionCreateFailed { plugin: XrmPlugin::Encoder });
     }
 
     Ok(enc_session)

--- a/xilinx/src/xlnx_error.rs
+++ b/xilinx/src/xlnx_error.rs
@@ -58,3 +58,61 @@ impl fmt::Debug for XlnxError {
         write!(f, "XlnxError {{ err: {:?}, message: {:?} }}", self.err, self.message,)
     }
 }
+
+#[derive(Debug, thiserror::Error)]
+pub enum Error {
+    #[error("plugin {plugin:?} gave a malformed response")]
+    MalformedPluginResponse { plugin: XrmPlugin },
+    #[error("internal Xilinx error {source}")]
+    XlnxError {
+        #[from]
+        source: XlnxError,
+    },
+    #[error("error loading dynamic library {source}")]
+    Libloading {
+        #[from]
+        source: libloading::Error,
+    },
+    #[error("XRM API failed to release reserved compute unit pool")]
+    FailedToReleaseCuPool { plugin: XrmPlugin },
+    #[error("XRM API failed to release reserved compute units")]
+    FailedToReleaseCu { plugin: XrmPlugin },
+    #[error("failed to reserve {plugin:?} compute unit pool on Xilinx hardware")]
+    ReserveCuPoolError { plugin: XrmPlugin },
+    #[error("failed to reserve {plugin:?} compute units on Xilinx hardware for reserve_id {reserve_id:?} and device_id {device_id:?} xilinx error: {xlnx_error_code}")]
+    ReserveCuError {
+        plugin: XrmPlugin,
+        reserve_id: Option<u64>,
+        device_id: Option<u32>,
+        xlnx_error_code: i32,
+    },
+    #[error("required parameter(s) not provided: {parameter_names}")]
+    RequiredParameterMissing { parameter_names: &'static str },
+    #[error("unable to create session for {plugin:?}")]
+    SessionCreateFailed { plugin: XrmPlugin },
+    #[error("invalid profile number {number} for {plugin:?} using codec {codec:?}")]
+    InvalidCodecProfile { plugin: XrmPlugin, number: i32, codec: XrmCodec },
+    #[error("invalid codec level value {level} using codec {codec:?} for {plugin:?}")]
+    InvalidCodecLevel { plugin: XrmPlugin, level: i32, codec: XrmCodec },
+    #[error("invalid codec id {codec} for {plugin:?}")]
+    InvalidCodecId { plugin: XrmPlugin, codec: i32 },
+    #[error("no device found with device id {device_id}")]
+    DeviceNotFound { device_id: i32 },
+    #[error("input str {input_str} exceeds output buffer size of {out_buf_size}")]
+    InputStrExceedsOutputBufferSize { out_buf_size: usize, input_str: String },
+}
+
+#[derive(Debug)]
+pub enum XrmPlugin {
+    Decoder,
+    Encoder,
+    Scaler,
+    /// AKA Encoder and Decoder used together
+    Transcoder,
+}
+
+#[derive(Debug)]
+pub enum XrmCodec {
+    Hevc,
+    H264,
+}

--- a/xilinx/src/xlnx_scal_utils.rs
+++ b/xilinx/src/xlnx_scal_utils.rs
@@ -1,12 +1,11 @@
 use libloading::{Library, Symbol};
-use simple_error::{bail, SimpleError};
 use std::{ffi::CString, os::raw::c_char, str::from_utf8};
 
-use crate::{strcpy_to_arr_i8, sys::*, xrm_precision_1000000_bitmask, XrmContext};
+use crate::{strcpy_to_arr_i8, sys::*, xrm_precision_1000000_bitmask, Error, XlnxError, XrmContext, XrmPlugin};
 
 const SCAL_PLUGIN_NAME: &[u8] = b"xrmU30ScalPlugin\0";
 
-pub struct XlnxScalerXrmCtx<'a> {
+pub(crate) struct XlnxScalerXrmCtx<'a> {
     pub xrm_reserve_id: Option<u64>,
     pub device_id: Option<u32>,
     pub scal_load: i32,
@@ -31,30 +30,21 @@ impl<'a> XlnxScalerXrmCtx<'a> {
 }
 
 #[allow(clippy::not_unsafe_ptr_arg_deref)]
-pub fn xlnx_calc_scal_load(xrm_ctx: &XrmContext, xma_scal_props: *mut XmaScalerProperties) -> Result<i32, SimpleError> {
+pub fn xlnx_calc_scal_load(xrm_ctx: &XrmContext, xma_scal_props: *mut XmaScalerProperties) -> Result<i32, Error> {
     let func_id = 0;
     let mut plugin_param: xrmPluginFuncParam = Default::default();
     unsafe {
-        match Library::new("/opt/xilinx/xrm/plugin/libxmaPropsTOjson.so") {
-            Ok(lib) => {
-                match lib
-                    .get::<Symbol<extern "C" fn(props: *mut XmaScalerProperties, function: *const c_char, json_params: *mut c_char)>>(b"convertXmaPropsToJson")
-                {
-                    Ok(convert_xma_props_to_json) => {
-                        let function = CString::new("SCALER").unwrap();
-                        convert_xma_props_to_json(xma_scal_props, function.as_ptr(), plugin_param.input.as_mut_ptr());
-                    }
-                    Err(e) => bail!("{}", e),
-                }
-            }
-            Err(e) => bail!("{}", e),
-        };
+        let lib = Library::new("/opt/xilinx/xrm/plugin/libxmaPropsTOjson.so")?;
+        let convert_xma_props_to_json =
+            lib.get::<Symbol<extern "C" fn(props: *mut XmaScalerProperties, function: *const c_char, json_params: *mut c_char)>>(b"convertXmaPropsToJson")?;
+        let function = CString::new("SCALER").unwrap();
+        convert_xma_props_to_json(xma_scal_props, function.as_ptr(), plugin_param.input.as_mut_ptr());
     }
 
     unsafe {
         let ret = xrmExecPluginFunc(xrm_ctx.raw(), SCAL_PLUGIN_NAME.as_ptr() as *mut i8, func_id, &mut plugin_param);
         if ret != XRM_SUCCESS as i32 {
-            bail!("XRM Scaler plugin failed to calculate scaler load. error: {}", ret);
+            return Err(XlnxError::new(ret, Some("XRM Scaler plugin failed to calculate scaler load.".to_string())).into());
         }
     }
     // parse the load from the output buffer of plugin param.
@@ -67,13 +57,13 @@ pub fn xlnx_calc_scal_load(xrm_ctx: &XrmContext, xma_scal_props: *mut XmaScalerP
     let load = scal_plugin_output.parse::<i32>().unwrap_or(-1);
 
     if load == -1 {
-        bail!("unable to parse load calculation from XRM scaler plugin");
+        return Err(Error::MalformedPluginResponse { plugin: XrmPlugin::Scaler });
     }
 
     Ok(load)
 }
 
-fn xlnx_fill_scal_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, scal_load: i32, device_id: Option<u32>) -> Result<(), SimpleError> {
+fn xlnx_fill_scal_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, scal_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     cu_pool_prop.cuListNum = 1;
 
     let mut device_info = 0;
@@ -93,7 +83,7 @@ fn xlnx_fill_scal_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, scal_load: 
     Ok(())
 }
 
-pub fn xlnx_reserve_scal_resource(xlnx_scal_ctx: &mut XlnxScalerXrmCtx) -> Result<Box<xrmCuPoolResInforV2>, SimpleError> {
+pub(crate) fn xlnx_reserve_scal_resource(xlnx_scal_ctx: &mut XlnxScalerXrmCtx) -> Result<Box<xrmCuPoolResInforV2>, Error> {
     let mut cu_pool_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
     let mut cu_pool_res_infor: Box<xrmCuPoolResInforV2> = Box::new(Default::default());
     xlnx_fill_scal_pool_props(&mut cu_pool_prop, xlnx_scal_ctx.scal_load, xlnx_scal_ctx.device_id)?;
@@ -101,12 +91,12 @@ pub fn xlnx_reserve_scal_resource(xlnx_scal_ctx: &mut XlnxScalerXrmCtx) -> Resul
     unsafe {
         let num_cu_pool = xrmCheckCuPoolAvailableNumV2(xlnx_scal_ctx.xrm_ctx.raw(), cu_pool_prop.as_mut());
         if num_cu_pool == 0 {
-            bail!("no scaler resources available for allocation")
+            return Err(Error::ReserveCuPoolError { plugin: XrmPlugin::Scaler });
         }
 
         let xrm_reserve_id = xrmCuPoolReserveV2(xlnx_scal_ctx.xrm_ctx.raw(), cu_pool_prop.as_mut(), cu_pool_res_infor.as_mut());
         if xrm_reserve_id == 0 {
-            bail!("failed to reserve scaler cu pool")
+            return Err(Error::ReserveCuPoolError { plugin: XrmPlugin::Scaler });
         }
         xlnx_scal_ctx.xrm_reserve_id = Some(xrm_reserve_id);
     }
@@ -114,22 +104,19 @@ pub fn xlnx_reserve_scal_resource(xlnx_scal_ctx: &mut XlnxScalerXrmCtx) -> Resul
     Ok(cu_pool_res_infor)
 }
 
-pub(crate) fn xlnx_create_scal_session(
-    xma_scal_props: &mut XmaScalerProperties,
-    xlnx_scal_ctx: &mut XlnxScalerXrmCtx,
-) -> Result<*mut XmaScalerSession, SimpleError> {
+pub(crate) fn xlnx_create_scal_session(xma_scal_props: &mut XmaScalerProperties, xlnx_scal_ctx: &mut XlnxScalerXrmCtx) -> Result<*mut XmaScalerSession, Error> {
     xma_scal_props.num_outputs = xlnx_scal_ctx.num_outputs;
     xlnx_scal_cu_alloc(xma_scal_props, xlnx_scal_ctx)?;
 
     let scal_session = unsafe { xma_scaler_session_create(xma_scal_props) };
     if scal_session.is_null() {
-        bail!("failed to create scaler session. Session is null")
+        return Err(Error::SessionCreateFailed { plugin: XrmPlugin::Scaler });
     }
 
     Ok(scal_session)
 }
 
-fn xlnx_scal_cu_alloc(xma_scal_props: &mut XmaScalerProperties, xlnx_scal_ctx: &mut XlnxScalerXrmCtx<'_>) -> Result<(), SimpleError> {
+fn xlnx_scal_cu_alloc(xma_scal_props: &mut XmaScalerProperties, xlnx_scal_ctx: &mut XlnxScalerXrmCtx<'_>) -> Result<(), Error> {
     let mut scaler_cu_prop: Box<xrmCuPropertyV2> = Box::new(Default::default());
 
     strcpy_to_arr_i8(&mut scaler_cu_prop.kernelName, "scaler")?;
@@ -153,16 +140,29 @@ fn xlnx_scal_cu_alloc(xma_scal_props: &mut XmaScalerProperties, xlnx_scal_ctx: &
             scaler_cu_prop.poolId = reserve_id;
         }
         (None, None) => {
-            bail!("failed to allocate scaler cu: no device id or reserve id provided");
+            return Err(Error::ReserveCuPoolError { plugin: XrmPlugin::Scaler });
         }
     }
 
-    if unsafe { xrmCuAllocV2(xlnx_scal_ctx.xrm_ctx.raw(), scaler_cu_prop.as_mut(), xlnx_scal_ctx.cu_res.as_mut()) } != XRM_SUCCESS as _ {
-        bail!(
-            "failed to allocate scaler cu from reserve id {:?} and device id {:?}",
-            xlnx_scal_ctx.xrm_reserve_id,
-            xlnx_scal_ctx.device_id
-        );
+    // If this context was used for a reservation previously, release it now.
+    // This is almost certainly dead code but if it does somehow get run
+    // it would prevent a leak of CU resources.
+    if xlnx_scal_ctx.scal_res_in_use {
+        if unsafe { xrmCuReleaseV2(xlnx_scal_ctx.xrm_ctx.raw(), xlnx_scal_ctx.cu_res.as_mut()) } {
+            xlnx_scal_ctx.scal_res_in_use = false;
+        } else {
+            return Err(Error::FailedToReleaseCu { plugin: XrmPlugin::Scaler });
+        }
+    }
+
+    let ret = unsafe { xrmCuAllocV2(xlnx_scal_ctx.xrm_ctx.raw(), scaler_cu_prop.as_mut(), xlnx_scal_ctx.cu_res.as_mut()) };
+    if ret != XRM_SUCCESS as _ {
+        return Err(Error::ReserveCuError {
+            plugin: XrmPlugin::Scaler,
+            reserve_id: xlnx_scal_ctx.xrm_reserve_id,
+            device_id: xlnx_scal_ctx.device_id,
+            xlnx_error_code: ret,
+        });
     }
     xlnx_scal_ctx.scal_res_in_use = true;
 

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -1,7 +1,6 @@
-use std::marker::PhantomData;
+use std::mem::ManuallyDrop;
 
-use crate::{sys::*, xlnx_error::*, xlnx_scal_utils::*};
-use simple_error::SimpleError;
+use crate::{sys::*, xlnx_error::*, xlnx_scal_utils::*, XrmContext};
 
 pub const SCAL_MAX_ABR_CHANNELS: usize = 8;
 pub const SCAL_MAX_SESSIONS: usize = 2;
@@ -9,15 +8,23 @@ pub const SCAL_RATE_STRING_LEN: usize = 8;
 
 pub struct XlnxScaler<'a> {
     scal_session: *mut XmaScalerSession,
-    pub out_frame_list: Vec<*mut XmaFrame>,
-    pub xrm_scalres_count: i32,
-    pub flush_sent: bool,
-    scaler_ctx_lifetime: PhantomData<XlnxScalerXrmCtx<'a>>,
+    out_frame_list: Vec<*mut XmaFrame>,
+    xrm_scalres_count: i32,
+    flush_sent: bool,
+    xlnx_scaler_ctx: ManuallyDrop<XlnxScalerXrmCtx<'a>>,
 }
 
 impl<'a> XlnxScaler<'a> {
-    pub fn new(xma_scal_props: &mut XmaScalerProperties, xlnx_scal_ctx: &mut XlnxScalerXrmCtx<'a>) -> Result<Self, SimpleError> {
-        let scal_session = xlnx_create_scal_session(xma_scal_props, xlnx_scal_ctx)?;
+    pub fn new(
+        xrm_ctx: &'a XrmContext,
+        xma_scal_props: &mut XmaScalerProperties,
+        device_id: Option<u32>,
+        reserve_id: Option<u64>,
+        scal_load: i32,
+    ) -> Result<Self, Error> {
+        let mut xlnx_scaler_ctx = XlnxScalerXrmCtx::new(xrm_ctx, device_id, reserve_id, scal_load, xma_scal_props.num_outputs);
+        xlnx_reserve_scal_resource(&mut xlnx_scaler_ctx)?;
+        let scal_session = xlnx_create_scal_session(xma_scal_props, &mut xlnx_scaler_ctx)?;
 
         let mut out_frame_list = Vec::new();
 
@@ -49,8 +56,16 @@ impl<'a> XlnxScaler<'a> {
             out_frame_list,
             xrm_scalres_count: xma_scal_props.num_outputs,
             flush_sent: false,
-            scaler_ctx_lifetime: PhantomData,
+            xlnx_scaler_ctx: ManuallyDrop::new(xlnx_scaler_ctx),
         })
+    }
+
+    pub fn num_outputs(&self) -> i32 {
+        self.xrm_scalres_count
+    }
+
+    pub fn flush_sent(&self) -> bool {
+        self.flush_sent
     }
 
     /// Sends frame to xilinx scaler using xma plugin
@@ -109,13 +124,14 @@ impl<'a> Drop for XlnxScaler<'a> {
                     xma_frame_free(f);
                 }
             }
+            ManuallyDrop::drop(&mut self.xlnx_scaler_ctx);
         }
     }
 }
 
 #[cfg(test)]
 mod scaler_tests {
-    use crate::{tests::*, xlnx_scal_props::*, xlnx_scal_utils::*, xlnx_scaler::*, xrm_context::*};
+    use crate::{tests::*, xlnx_scal_props::*, xlnx_scal_utils::*, xlnx_scaler::*};
 
     #[test]
     fn test_abr_scale() {
@@ -148,12 +164,9 @@ mod scaler_tests {
 
         let xrm_ctx = XrmContext::new();
         let scal_load = xlnx_calc_scal_load(&xrm_ctx, xma_scal_props.as_mut()).unwrap();
-        let mut xlnx_scal_ctx = XlnxScalerXrmCtx::new(&xrm_ctx, None, None, scal_load, 3);
-
-        xlnx_reserve_scal_resource(&mut xlnx_scal_ctx).unwrap();
 
         // create xlnx scaler
-        let mut scaler = XlnxScaler::new(xma_scal_props.as_mut(), &mut xlnx_scal_ctx).unwrap();
+        let mut scaler = XlnxScaler::new(&xrm_ctx, xma_scal_props.as_mut(), None, None, scal_load).unwrap();
 
         let mut processed_frame_count = 0;
 
@@ -163,7 +176,7 @@ mod scaler_tests {
                     // successfully scaled frame.
                     processed_frame_count += 1;
                     // clear xvbm buffers for each return frame
-                    for i in 0..xlnx_scal_ctx.num_outputs as usize {
+                    for i in 0..scaler.num_outputs() as usize {
                         unsafe {
                             let handle: XvbmBufferHandle = (*scaler.out_frame_list[i]).data[0].buffer;
                             xvbm_buffer_pool_entry_free(handle);
@@ -197,7 +210,7 @@ mod scaler_tests {
                         // successfully scaled frame.
                         processed_frame_count += 1;
                         // clear xvbm buffers for each return frame
-                        for i in 0..xlnx_scal_ctx.num_outputs as usize {
+                        for i in 0..scaler.num_outputs() as usize {
                             let handle: XvbmBufferHandle = (*scaler.out_frame_list[i]).data[0].buffer;
                             xvbm_buffer_pool_entry_free(handle);
                         }

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -68,6 +68,10 @@ impl<'a> XlnxScaler<'a> {
         self.flush_sent
     }
 
+    pub fn out_frame_list(&self) -> &[*mut XmaFrame] {
+        &self.out_frame_list
+    }
+
     /// Sends frame to xilinx scaler using xma plugin
     ///
     /// @in_frame: decoded frame input to be scaled.


### PR DESCRIPTION
This PR has several breaking changes that are all related to removing footguns and making the API easier to use correctly.

- Stop using `simple_error` and swap out for a `thiserror` based implementation. This makes it easier to process these errors programmatically.
- Remove `Xlnx*XrmCtx` types from the public API. These types have a few usability warts.
  - Their lifetime is necessarily tied to the corresponding `XlnxDecoder`, `XlnxEncoder`, or `XlnxScaler`. So you can't drop the `Xlnx*XrmCtx` without first having dropped the session type.
  - Each `Xlnx*XrmCtx` can only support one downstream session at a time. As-is using the context to create an additional session will actually leak compute unit reservations.
  
  So it makes more sense to remove them from the public API, and then make them part of the downstream session object. This makes it easier to guarantee that the `Xlnx*XrmCtx` is interacted with in a correct manner.
  
- Remove functions that allocate compute units from the public API, instead call these when the relevant session object is created. This made more sense to me as the corresponding release of compute units happens when the `Xlnx*XrmCtx` object is released anyways.

- Move some public properties to private, add getters for them. This closes a gap where it was possible to modify these properties after they'd been set correctly or sent to Xilinx APIs.

Ideas for future work

- There's a lot of repetitive code here. Can we use generics and traits more to reduce repetition?