### PR TITLE
More xilinx improvements

### DIFF
--- a/xilinx/src/lib.rs
+++ b/xilinx/src/lib.rs
@@ -106,7 +106,7 @@ pub(crate) fn strcpy_to_arr_i8(buf: &mut [i8], in_str: &str) -> Result<(), Error
 
 #[cfg(test)]
 pub mod tests {
-    use crate::{sys::*, xlnx_init_all_devices};
+    use crate::{sys::*, xlnx_init_all_devices, XrmContext};
     use std::sync::Once;
 
     use std::{fs::File, io::Read};
@@ -181,5 +181,14 @@ pub mod tests {
         }
 
         (frames, y_components, uv_components)
+    }
+
+    #[test]
+    fn test_cu_available() {
+        initialize();
+        let xrm_ctx = XrmContext::new();
+        xrm_ctx.dec_cu_available().unwrap();
+        xrm_ctx.enc_cu_available().unwrap();
+        xrm_ctx.scal_cu_available().unwrap();
     }
 }

--- a/xilinx/src/xlnx_dec_utils.rs
+++ b/xilinx/src/xlnx_dec_utils.rs
@@ -6,13 +6,6 @@ use crate::{strcpy_to_arr_i8, sys::*, xrm_precision_1000000_bitmask, Error, Xlnx
 
 const DEC_PLUGIN_NAME: &[u8] = b"xrmU30DecPlugin\0";
 
-#[derive(Clone, Debug)]
-pub struct XlnxDecBuffer<'a> {
-    pub data: &'a [u8],
-    pub size: usize,
-    pub allocated: usize,
-}
-
 pub(crate) struct XlnxDecoderXrmCtx<'a> {
     pub xrm_reserve_id: Option<u64>,
     pub device_id: Option<u32>,
@@ -70,7 +63,7 @@ pub fn xlnx_calc_dec_load(xrm_ctx: &XrmContext, xma_dec_props: *mut XmaDecoderPr
     Ok(load)
 }
 
-fn xlnx_fill_dec_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, dec_load: i32, device_id: Option<u32>) -> Result<(), Error> {
+pub(crate) fn xlnx_fill_dec_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, dec_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     cu_pool_prop.cuListNum = 1;
 
     let mut device_info = 0;

--- a/xilinx/src/xlnx_enc_utils.rs
+++ b/xilinx/src/xlnx_enc_utils.rs
@@ -61,7 +61,7 @@ pub fn xlnx_calc_enc_load(xrm_ctx: &XrmContext, xma_enc_props: *mut XmaEncoderPr
     Ok(load)
 }
 
-fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, enc_count: i32, enc_load: i32, device_id: Option<u32>) -> Result<(), Error> {
+pub(crate) fn xlnx_fill_enc_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, enc_count: i32, enc_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     cu_pool_prop.cuListNum = 1;
     let mut cu_num = 0;
     let mut device_info = 0;

--- a/xilinx/src/xlnx_scal_utils.rs
+++ b/xilinx/src/xlnx_scal_utils.rs
@@ -63,7 +63,7 @@ pub fn xlnx_calc_scal_load(xrm_ctx: &XrmContext, xma_scal_props: *mut XmaScalerP
     Ok(load)
 }
 
-fn xlnx_fill_scal_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, scal_load: i32, device_id: Option<u32>) -> Result<(), Error> {
+pub(crate) fn xlnx_fill_scal_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, scal_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     cu_pool_prop.cuListNum = 1;
     xlnx_fill_scal_cu_props(&mut cu_pool_prop.cuListProp.cuProps[0], scal_load, device_id)?;
     cu_pool_prop.cuListProp.cuNum = 1;
@@ -71,7 +71,7 @@ fn xlnx_fill_scal_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, scal_load: 
     Ok(())
 }
 
-pub(crate) fn xlnx_fill_scal_cu_props(cu_prop: &mut xrmCuPropertyV2, scal_load: i32, device_id: Option<u32>) -> Result<(), Error> {
+fn xlnx_fill_scal_cu_props(cu_prop: &mut xrmCuPropertyV2, scal_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     let mut device_info = 0;
 
     if let Some(device_id) = device_id {

--- a/xilinx/src/xlnx_scal_utils.rs
+++ b/xilinx/src/xlnx_scal_utils.rs
@@ -65,7 +65,13 @@ pub fn xlnx_calc_scal_load(xrm_ctx: &XrmContext, xma_scal_props: *mut XmaScalerP
 
 fn xlnx_fill_scal_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, scal_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     cu_pool_prop.cuListNum = 1;
+    xlnx_fill_scal_cu_props(&mut cu_pool_prop.cuListProp.cuProps[0], scal_load, device_id)?;
+    cu_pool_prop.cuListProp.cuNum = 1;
 
+    Ok(())
+}
+
+pub(crate) fn xlnx_fill_scal_cu_props(cu_prop: &mut xrmCuPropertyV2, scal_load: i32, device_id: Option<u32>) -> Result<(), Error> {
     let mut device_info = 0;
 
     if let Some(device_id) = device_id {
@@ -73,12 +79,11 @@ fn xlnx_fill_scal_pool_props(cu_pool_prop: &mut xrmCuPoolPropertyV2, scal_load: 
             | ((XRM_DEVICE_INFO_CONSTRAINT_TYPE_HARDWARE_DEVICE_INDEX as u64) << XRM_DEVICE_INFO_CONSTRAINT_TYPE_SHIFT);
     }
 
-    strcpy_to_arr_i8(&mut cu_pool_prop.cuListProp.cuProps[0].kernelName, "scaler")?;
-    strcpy_to_arr_i8(&mut cu_pool_prop.cuListProp.cuProps[0].kernelAlias, "SCALER_MPSOC")?;
-    cu_pool_prop.cuListProp.cuProps[0].devExcl = false;
-    cu_pool_prop.cuListProp.cuProps[0].requestLoad = xrm_precision_1000000_bitmask(scal_load);
-    cu_pool_prop.cuListProp.cuProps[0].deviceInfo = device_info as _;
-    cu_pool_prop.cuListProp.cuNum = 1;
+    strcpy_to_arr_i8(&mut cu_prop.kernelName, "scaler")?;
+    strcpy_to_arr_i8(&mut cu_prop.kernelAlias, "SCALER_MPSOC")?;
+    cu_prop.devExcl = false;
+    cu_prop.requestLoad = xrm_precision_1000000_bitmask(scal_load);
+    cu_prop.deviceInfo = device_info as _;
 
     Ok(())
 }

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -8,9 +8,8 @@ pub const SCAL_RATE_STRING_LEN: usize = 8;
 
 pub struct XlnxScaler<'a> {
     scal_session: *mut XmaScalerSession,
-    pub out_frame_list: Vec<*mut XmaFrame>,
+    out_frame_list: Vec<*mut XmaFrame>,
     xrm_scalres_count: i32,
-    pub flush_sent: bool,
     xlnx_scaler_ctx: ManuallyDrop<XlnxScalerXrmCtx<'a>>,
 }
 
@@ -55,17 +54,12 @@ impl<'a> XlnxScaler<'a> {
             scal_session,
             out_frame_list,
             xrm_scalres_count: xma_scal_props.num_outputs,
-            flush_sent: false,
             xlnx_scaler_ctx: ManuallyDrop::new(xlnx_scaler_ctx),
         })
     }
 
     pub fn num_outputs(&self) -> i32 {
         self.xrm_scalres_count
-    }
-
-    pub fn flush_sent(&self) -> bool {
-        self.flush_sent
     }
 
     pub fn out_frame_list(&self) -> &[*mut XmaFrame] {

--- a/xilinx/src/xlnx_scaler.rs
+++ b/xilinx/src/xlnx_scaler.rs
@@ -8,9 +8,9 @@ pub const SCAL_RATE_STRING_LEN: usize = 8;
 
 pub struct XlnxScaler<'a> {
     scal_session: *mut XmaScalerSession,
-    out_frame_list: Vec<*mut XmaFrame>,
+    pub out_frame_list: Vec<*mut XmaFrame>,
     xrm_scalres_count: i32,
-    flush_sent: bool,
+    pub flush_sent: bool,
     xlnx_scaler_ctx: ManuallyDrop<XlnxScalerXrmCtx<'a>>,
 }
 

--- a/xilinx/src/xrm_context.rs
+++ b/xilinx/src/xrm_context.rs
@@ -1,9 +1,12 @@
-use crate::{sys, xlnx_fill_dec_pool_props, xlnx_fill_enc_pool_props, xlnx_fill_scal_cu_props, xrmCheckCuAvailableNumV2, xrmCheckCuPoolAvailableNumV2, xrmCuPoolPropertyV2, xrmCuPropertyV2, Error};
+use crate::{sys, xlnx_fill_dec_pool_props, xlnx_fill_enc_pool_props, xlnx_fill_scal_pool_props, xrmCheckCuPoolAvailableNumV2, xrmCuPoolPropertyV2, Error};
 
 /// A wrapper of the XrmContext which will correctly drop the context when dropped
 pub struct XrmContext {
     context: sys::xrmContext,
 }
+
+unsafe impl Send for XrmContext {}
+// Sync is omitted on purpose as I have no reason to believe these APIs are thread safe.
 
 impl XrmContext {
     pub fn new() -> Self {
@@ -17,10 +20,10 @@ impl XrmContext {
     }
 
     pub fn scal_cu_available(&self) -> Result<i32, Error> {
-        let mut cu_prop: Box<xrmCuPropertyV2> = Box::new(Default::default());
-        xlnx_fill_scal_cu_props(cu_prop.as_mut(), 1, None)?;
+        let mut cu_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
+        xlnx_fill_scal_pool_props(cu_prop.as_mut(), 1, None)?;
 
-        let num_cu = unsafe { xrmCheckCuAvailableNumV2(self.raw(), cu_prop.as_mut()) };
+        let num_cu = unsafe { xrmCheckCuPoolAvailableNumV2(self.raw(), cu_prop.as_mut()) };
         Ok(num_cu)
     }
 

--- a/xilinx/src/xrm_context.rs
+++ b/xilinx/src/xrm_context.rs
@@ -1,4 +1,4 @@
-use crate::sys;
+use crate::{sys, xlnx_fill_dec_pool_props, xlnx_fill_enc_pool_props, xlnx_fill_scal_cu_props, xrmCheckCuAvailableNumV2, xrmCheckCuPoolAvailableNumV2, xrmCuPoolPropertyV2, xrmCuPropertyV2, Error};
 
 /// A wrapper of the XrmContext which will correctly drop the context when dropped
 pub struct XrmContext {
@@ -14,6 +14,28 @@ impl XrmContext {
     /// be freed. Do not use unless the source `XrmContext` still exists.
     pub unsafe fn raw(&self) -> sys::xrmContext {
         self.context
+    }
+
+    pub fn scal_cu_available(&self) -> Result<i32, Error> {
+        let mut cu_prop: Box<xrmCuPropertyV2> = Box::new(Default::default());
+        xlnx_fill_scal_cu_props(cu_prop.as_mut(), 1, None)?;
+
+        let num_cu = unsafe { xrmCheckCuAvailableNumV2(self.raw(), cu_prop.as_mut()) };
+        Ok(num_cu)
+    }
+
+    pub fn dec_cu_available(&self) -> Result<i32, Error> {
+        let mut cu_pool_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
+        xlnx_fill_dec_pool_props(&mut cu_pool_prop, 1, None)?;
+        let num_cu_pool = unsafe { xrmCheckCuPoolAvailableNumV2(self.raw(), cu_pool_prop.as_mut()) };
+        Ok(num_cu_pool)
+    }
+
+    pub fn enc_cu_available(&self) -> Result<i32, Error> {
+        let mut cu_pool_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
+        xlnx_fill_enc_pool_props(&mut cu_pool_prop, 1, 1, None)?;
+        let num_cu_pool = unsafe { xrmCheckCuPoolAvailableNumV2(self.raw(), cu_pool_prop.as_mut()) };
+        Ok(num_cu_pool)
     }
 }
 

--- a/xilinx/src/xrm_context.rs
+++ b/xilinx/src/xrm_context.rs
@@ -1,6 +1,6 @@
 use crate::{sys, xlnx_fill_dec_pool_props, xlnx_fill_enc_pool_props, xlnx_fill_scal_pool_props, xrmCheckCuPoolAvailableNumV2, xrmCuPoolPropertyV2, Error};
 
-/// A wrapper of the XrmContext which will correctly drop the context when dropped
+/// A wrapper of the XrmContext which will correctly drop the context when dropped.
 pub struct XrmContext {
     context: sys::xrmContext,
 }
@@ -19,23 +19,31 @@ impl XrmContext {
         self.context
     }
 
+    /// An unloaded U30 card has 2000 scaling units available. This should be used exclusively for monitoring scaling resources, not for reservations. It shouldn't even
+    /// be used to determine if you can make a reservation.
     pub fn scal_cu_available(&self) -> Result<i32, Error> {
         let mut cu_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
+        // Use a load of 1 to get the most fine grained result
         xlnx_fill_scal_pool_props(cu_prop.as_mut(), 1, None)?;
-
         let num_cu = unsafe { xrmCheckCuPoolAvailableNumV2(self.raw(), cu_prop.as_mut()) };
         Ok(num_cu)
     }
 
+    /// An unloaded U30 card has 64 decoding units available. This should be used exclusively for monitoring decoding resources, not for reservations. It shouldn't even
+    /// be used to determine if you can make a reservation.
     pub fn dec_cu_available(&self) -> Result<i32, Error> {
         let mut cu_pool_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
+        // Use a load of 1 to get the most fine grained result
         xlnx_fill_dec_pool_props(&mut cu_pool_prop, 1, None)?;
         let num_cu_pool = unsafe { xrmCheckCuPoolAvailableNumV2(self.raw(), cu_pool_prop.as_mut()) };
         Ok(num_cu_pool)
     }
 
+    /// An unloaded U30 card has 64 encoding units available. This should be used exclusively for monitoring encoding resources, not for reservations. It shouldn't even
+    /// be used to determine if you can make a reservation.
     pub fn enc_cu_available(&self) -> Result<i32, Error> {
         let mut cu_pool_prop: Box<xrmCuPoolPropertyV2> = Box::new(Default::default());
+        // Use a load of 1 to get the most fine grained result
         xlnx_fill_enc_pool_props(&mut cu_pool_prop, 1, 1, None)?;
         let num_cu_pool = unsafe { xrmCheckCuPoolAvailableNumV2(self.raw(), cu_pool_prop.as_mut()) };
         Ok(num_cu_pool)


### PR DESCRIPTION
- Add APIs to the `XrmContext` which will tell how many CUs are available for each kernel type.
- Remove unused `XlnxDecBuffer` structure.