### PR TITLE
Disable MacOS CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -8,10 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-24.04, macos-12-large]
-        include:
-          - os: macos-12-large
-            args: --exclude v4l2
+        os: [ubuntu-24.04]
     steps:
     - uses: actions/checkout@v4
       with:


### PR DESCRIPTION
macos-12-large is no longer available. Maybe someday we'll put MacOS runners back, maybe we won't.