### PR TITLE
add avchd metadata decoding to h264 crate

### DIFF
--- a/h264/src/sei.rs
+++ b/h264/src/sei.rs
@@ -246,10 +246,10 @@ pub struct UserDataUnregistered {
 
 impl UserDataUnregistered {
     pub fn decode<T: Iterator<Item = u8>>(mut bs: Bitstream<T>) -> io::Result<Self> {
-        let mut ret = Self::default();
-        ret.uuid_iso_iec_11578 = (bs.read_bits(64)? as u128) << 64 | bs.read_bits(64)? as u128;
-        ret.user_data_payload = bs.into_inner().collect();
-        Ok(ret)
+        Ok(Self {
+            uuid_iso_iec_11578: (bs.read_bits(64)? as u128) << 64 | bs.read_bits(64)? as u128,
+            user_data_payload: bs.into_inner().collect(),
+        })
     }
 }
 


### PR DESCRIPTION
We came across some video that encodes wallclock timestamps via AVCHD metadata in SEI message payloads. This adds some structs to decode them.